### PR TITLE
feat: Add base gas limit to bridge adapters

### DIFF
--- a/scripts/Adapters/BaseAdapterScript.sol
+++ b/scripts/Adapters/BaseAdapterScript.sol
@@ -7,6 +7,10 @@ import '../../src/contracts/adapters/IBaseAdapter.sol';
 abstract contract BaseAdapterScript is BaseScript {
   function REMOTE_NETWORKS() public view virtual returns (uint256[] memory);
 
+  function GET_BASE_GAS_LIMIT() public view virtual returns (uint256) {
+    return 0;
+  }
+
   function _deployAdapter(
     DeployerHelpers.Addresses memory addresses,
     IBaseAdapter.TrustedRemotesConfig[] memory trustedRemotes

--- a/scripts/Adapters/DeployArbAdapter.s.sol
+++ b/scripts/Adapters/DeployArbAdapter.s.sol
@@ -14,6 +14,10 @@ abstract contract BaseArbAdapter is BaseAdapterScript {
     return false;
   }
 
+  function GET_BASE_GAS_LIMIT() public view virtual override returns (uint256) {
+    return 150_000;
+  }
+
   function _deployAdapter(
     DeployerHelpers.Addresses memory addresses,
     IBaseAdapter.TrustedRemotesConfig[] memory trustedRemotes
@@ -24,12 +28,19 @@ abstract contract BaseArbAdapter is BaseAdapterScript {
           addresses.crossChainController,
           INBOX(),
           DESTINATION_CCC(),
+          GET_BASE_GAS_LIMIT(),
           trustedRemotes
         )
       );
     } else {
       addresses.arbAdapter = address(
-        new ArbAdapter(addresses.crossChainController, INBOX(), DESTINATION_CCC(), trustedRemotes)
+        new ArbAdapter(
+          addresses.crossChainController,
+          INBOX(),
+          DESTINATION_CCC(),
+          GET_BASE_GAS_LIMIT(),
+          trustedRemotes
+        )
       );
     }
   }

--- a/scripts/Adapters/DeployCBaseAdapter.s.sol
+++ b/scripts/Adapters/DeployCBaseAdapter.s.sol
@@ -18,11 +18,21 @@ abstract contract BaseCBAdapter is BaseAdapterScript {
   ) internal override {
     if (isTestnet()) {
       addresses.baseAdapter = address(
-        new CBaseAdapterTestnet(addresses.crossChainController, OVM(), trustedRemotes)
+        new CBaseAdapterTestnet(
+          addresses.crossChainController,
+          OVM(),
+          GET_BASE_GAS_LIMIT(),
+          trustedRemotes
+        )
       );
     } else {
       addresses.baseAdapter = address(
-        new CBaseAdapter(addresses.crossChainController, OVM(), trustedRemotes)
+        new CBaseAdapter(
+          addresses.crossChainController,
+          OVM(),
+          GET_BASE_GAS_LIMIT(),
+          trustedRemotes
+        )
       );
     }
   }

--- a/scripts/Adapters/DeployCCIP.s.sol
+++ b/scripts/Adapters/DeployCCIP.s.sol
@@ -23,13 +23,20 @@ abstract contract BaseCCIPAdapter is BaseAdapterScript {
         new CCIPAdapterTestnet(
           addresses.crossChainController,
           CCIP_ROUTER(),
+          GET_BASE_GAS_LIMIT(),
           trustedRemotes,
           LINK_TOKEN()
         )
       );
     } else {
       addresses.ccipAdapter = address(
-        new CCIPAdapter(addresses.crossChainController, CCIP_ROUTER(), trustedRemotes, LINK_TOKEN())
+        new CCIPAdapter(
+          addresses.crossChainController,
+          CCIP_ROUTER(),
+          GET_BASE_GAS_LIMIT(),
+          trustedRemotes,
+          LINK_TOKEN()
+        )
       );
     }
   }

--- a/scripts/Adapters/DeployGnosisChain.s.sol
+++ b/scripts/Adapters/DeployGnosisChain.s.sol
@@ -32,7 +32,12 @@ contract Ethereum is BaseGnosisChainAdapter {
     IBaseAdapter.TrustedRemotesConfig[] memory trustedRemotes
   ) internal override {
     addresses.gnosisAdapter = address(
-      new GnosisChainAdapter(addresses.crossChainController, GNOSIS_AMB_BRIDGE(), trustedRemotes)
+      new GnosisChainAdapter(
+        addresses.crossChainController,
+        GNOSIS_AMB_BRIDGE(),
+        GET_BASE_GAS_LIMIT(),
+        trustedRemotes
+      )
     );
   }
 }
@@ -57,7 +62,12 @@ contract Ethereum_testnet is BaseGnosisChainAdapter {
     IBaseAdapter.TrustedRemotesConfig[] memory trustedRemotes
   ) internal override {
     addresses.gnosisAdapter = address(
-      new GnosisChainAdapter(addresses.crossChainController, GNOSIS_AMB_BRIDGE(), trustedRemotes)
+      new GnosisChainAdapter(
+        addresses.crossChainController,
+        GNOSIS_AMB_BRIDGE(),
+        GET_BASE_GAS_LIMIT(),
+        trustedRemotes
+      )
     );
   }
 }
@@ -82,7 +92,12 @@ contract Gnosis is BaseGnosisChainAdapter {
     IBaseAdapter.TrustedRemotesConfig[] memory trustedRemotes
   ) internal override {
     addresses.gnosisAdapter = address(
-      new GnosisChainAdapter(addresses.crossChainController, GNOSIS_AMB_BRIDGE(), trustedRemotes)
+      new GnosisChainAdapter(
+        addresses.crossChainController,
+        GNOSIS_AMB_BRIDGE(),
+        GET_BASE_GAS_LIMIT(),
+        trustedRemotes
+      )
     );
   }
 }
@@ -108,7 +123,12 @@ contract Gnosis_testnet is BaseGnosisChainAdapter {
     IBaseAdapter.TrustedRemotesConfig[] memory trustedRemotes
   ) internal override {
     addresses.gnosisAdapter = address(
-      new GnosisChainAdapter(addresses.crossChainController, GNOSIS_AMB_BRIDGE(), trustedRemotes)
+      new GnosisChainAdapter(
+        addresses.crossChainController,
+        GNOSIS_AMB_BRIDGE(),
+        GET_BASE_GAS_LIMIT(),
+        trustedRemotes
+      )
     );
   }
 }

--- a/scripts/Adapters/DeployHL.s.sol
+++ b/scripts/Adapters/DeployHL.s.sol
@@ -14,7 +14,13 @@ abstract contract BaseHLAdapter is BaseAdapterScript {
     IBaseAdapter.TrustedRemotesConfig[] memory trustedRemotes
   ) internal override {
     addresses.hlAdapter = address(
-      new HyperLaneAdapter(addresses.crossChainController, HL_MAIL_BOX(), HL_IGP(), trustedRemotes)
+      new HyperLaneAdapter(
+        addresses.crossChainController,
+        HL_MAIL_BOX(),
+        HL_IGP(),
+        GET_BASE_GAS_LIMIT(),
+        trustedRemotes
+      )
     );
   }
 }

--- a/scripts/Adapters/DeployLZ.s.sol
+++ b/scripts/Adapters/DeployLZ.s.sol
@@ -18,11 +18,21 @@ abstract contract BaseLZAdapter is BaseAdapterScript {
     address lzAdapter;
     if (isTestNet()) {
       lzAdapter = address(
-        new LayerZeroAdapterTestnet(LZ_ENDPOINT(), addresses.crossChainController, trustedRemotes)
+        new LayerZeroAdapterTestnet(
+          LZ_ENDPOINT(),
+          addresses.crossChainController,
+          GET_BASE_GAS_LIMIT(),
+          trustedRemotes
+        )
       );
     } else {
       lzAdapter = address(
-        new LayerZeroAdapter(LZ_ENDPOINT(), addresses.crossChainController, trustedRemotes)
+        new LayerZeroAdapter(
+          LZ_ENDPOINT(),
+          addresses.crossChainController,
+          GET_BASE_GAS_LIMIT(),
+          trustedRemotes
+        )
       );
     }
     addresses.lzAdapter = lzAdapter;

--- a/scripts/Adapters/DeployMetisAdapter.s.sol
+++ b/scripts/Adapters/DeployMetisAdapter.s.sol
@@ -12,17 +12,31 @@ abstract contract BaseMetisAdapter is BaseAdapterScript {
     return false;
   }
 
+  function GET_BASE_GAS_LIMIT() public view virtual override returns (uint256) {
+    return 150_000;
+  }
+
   function _deployAdapter(
     DeployerHelpers.Addresses memory addresses,
     IBaseAdapter.TrustedRemotesConfig[] memory trustedRemotes
   ) internal override {
     if (isTestnet()) {
       addresses.metisAdapter = address(
-        new MetisAdapterTestnet(addresses.crossChainController, OVM(), trustedRemotes)
+        new MetisAdapterTestnet(
+          addresses.crossChainController,
+          OVM(),
+          GET_BASE_GAS_LIMIT(),
+          trustedRemotes
+        )
       );
     } else {
       addresses.metisAdapter = address(
-        new MetisAdapter(addresses.crossChainController, OVM(), trustedRemotes)
+        new MetisAdapter(
+          addresses.crossChainController,
+          OVM(),
+          GET_BASE_GAS_LIMIT(),
+          trustedRemotes
+        )
       );
     }
   }

--- a/scripts/Adapters/DeployOpAdapter.s.sol
+++ b/scripts/Adapters/DeployOpAdapter.s.sol
@@ -18,11 +18,16 @@ abstract contract BaseOpAdapter is BaseAdapterScript {
   ) internal override {
     if (isTestnet()) {
       addresses.opAdapter = address(
-        new OptimismAdapterTestnet(addresses.crossChainController, OVM(), trustedRemotes)
+        new OptimismAdapterTestnet(
+          addresses.crossChainController,
+          OVM(),
+          GET_BASE_GAS_LIMIT(),
+          trustedRemotes
+        )
       );
     } else {
       addresses.opAdapter = address(
-        new OpAdapter(addresses.crossChainController, OVM(), trustedRemotes)
+        new OpAdapter(addresses.crossChainController, OVM(), GET_BASE_GAS_LIMIT(), trustedRemotes)
       );
     }
   }

--- a/scripts/Adapters/DeployPolygon.s.sol
+++ b/scripts/Adapters/DeployPolygon.s.sol
@@ -31,7 +31,12 @@ contract Ethereum is BasePolygonAdapter {
     IBaseAdapter.TrustedRemotesConfig[] memory trustedRemotes
   ) internal override {
     addresses.polAdapter = address(
-      new PolygonAdapterEthereum(addresses.crossChainController, FX_TUNNEL(), trustedRemotes)
+      new PolygonAdapterEthereum(
+        addresses.crossChainController,
+        FX_TUNNEL(),
+        GET_BASE_GAS_LIMIT(),
+        trustedRemotes
+      )
     );
   }
 }
@@ -58,7 +63,12 @@ contract Polygon is BasePolygonAdapter {
     console2.log(addresses.crossChainController);
 
     addresses.polAdapter = address(
-      new PolygonAdapterPolygon(addresses.crossChainController, FX_TUNNEL(), trustedRemotes)
+      new PolygonAdapterPolygon(
+        addresses.crossChainController,
+        FX_TUNNEL(),
+        GET_BASE_GAS_LIMIT(),
+        trustedRemotes
+      )
     );
   }
 }
@@ -82,7 +92,12 @@ contract Ethereum_testnet is BasePolygonAdapter {
     IBaseAdapter.TrustedRemotesConfig[] memory trustedRemotes
   ) internal override {
     addresses.polAdapter = address(
-      new PolygonAdapterGoerli(addresses.crossChainController, FX_TUNNEL(), trustedRemotes)
+      new PolygonAdapterGoerli(
+        addresses.crossChainController,
+        FX_TUNNEL(),
+        GET_BASE_GAS_LIMIT(),
+        trustedRemotes
+      )
     );
   }
 }
@@ -106,7 +121,12 @@ contract Polygon_testnet is BasePolygonAdapter {
     IBaseAdapter.TrustedRemotesConfig[] memory trustedRemotes
   ) internal override {
     addresses.polAdapter = address(
-      new PolygonAdapterMumbai(addresses.crossChainController, FX_TUNNEL(), trustedRemotes)
+      new PolygonAdapterMumbai(
+        addresses.crossChainController,
+        FX_TUNNEL(),
+        GET_BASE_GAS_LIMIT(),
+        trustedRemotes
+      )
     );
   }
 }

--- a/scripts/Adapters/DeployZkEVMAdapter.s.sol
+++ b/scripts/Adapters/DeployZkEVMAdapter.s.sol
@@ -29,6 +29,7 @@ contract Ethereum is BaseAdapterScript {
       new ZkEVMAdapterEthereum(
         addresses.crossChainController,
         ZK_EVM_BRIDGE_MAINNET,
+        GET_BASE_GAS_LIMIT(),
         trustedRemotes
       )
     );
@@ -54,6 +55,7 @@ contract Zkevm is BaseAdapterScript {
       new ZkEVMAdapterPolygonZkEVM(
         addresses.crossChainController,
         ZK_EVM_BRIDGE_MAINNET,
+        GET_BASE_GAS_LIMIT(),
         trustedRemotes
       )
     );
@@ -76,7 +78,12 @@ contract Ethereum_testnet is BaseAdapterScript {
     IBaseAdapter.TrustedRemotesConfig[] memory trustedRemotes
   ) internal override {
     addresses.zkevmAdapter = address(
-      new ZkEVMAdapterGoerli(addresses.crossChainController, ZK_EVM_BRIDGE_TESTNET, trustedRemotes)
+      new ZkEVMAdapterGoerli(
+        addresses.crossChainController,
+        ZK_EVM_BRIDGE_TESTNET,
+        GET_BASE_GAS_LIMIT(),
+        trustedRemotes
+      )
     );
   }
 }
@@ -100,6 +107,7 @@ contract Zkevm_testnet is BaseAdapterScript {
       new ZkEVMAdapterZkEVMGoerli(
         addresses.crossChainController,
         ZK_EVM_BRIDGE_TESTNET,
+        GET_BASE_GAS_LIMIT(),
         trustedRemotes
       )
     );

--- a/scripts/contract_extensions/ArbitrumAdapter.sol
+++ b/scripts/contract_extensions/ArbitrumAdapter.sol
@@ -18,8 +18,9 @@ contract ArbitrumAdapterTestnet is ArbAdapter {
     address crossChainController,
     address inbox,
     address destinationCCC,
+    uint256 baseGasLimit,
     TrustedRemotesConfig[] memory trustedRemotes
-  ) ArbAdapter(crossChainController, inbox, destinationCCC, trustedRemotes) {}
+  ) ArbAdapter(crossChainController, inbox, destinationCCC, baseGasLimit, trustedRemotes) {}
 
   /// @inheritdoc IArbAdapter
   function isDestinationChainIdSupported(uint256 chainId) public pure override returns (bool) {

--- a/scripts/contract_extensions/CBAdapter.sol
+++ b/scripts/contract_extensions/CBAdapter.sol
@@ -17,8 +17,9 @@ contract CBaseAdapterTestnet is CBaseAdapter {
   constructor(
     address crossChainController,
     address ovmCrossDomainMessenger,
+    uint256 baseGasLimit,
     TrustedRemotesConfig[] memory trustedRemotes
-  ) CBaseAdapter(crossChainController, ovmCrossDomainMessenger, trustedRemotes) {}
+  ) CBaseAdapter(crossChainController, ovmCrossDomainMessenger, baseGasLimit, trustedRemotes) {}
 
   /// @inheritdoc IOpAdapter
   function isDestinationChainIdSupported(uint256 chainId) public pure override returns (bool) {

--- a/scripts/contract_extensions/CCIPAdapter.sol
+++ b/scripts/contract_extensions/CCIPAdapter.sol
@@ -19,9 +19,10 @@ contract CCIPAdapterTestnet is CCIPAdapter {
   constructor(
     address crossChainController,
     address ccipRouter,
+    uint256 baseGasLimit,
     TrustedRemotesConfig[] memory trustedRemotes,
     address linkToken
-  ) CCIPAdapter(crossChainController, ccipRouter, trustedRemotes, linkToken) {}
+  ) CCIPAdapter(crossChainController, ccipRouter, baseGasLimit, trustedRemotes, linkToken) {}
 
   /// @inheritdoc IBaseAdapter
   function nativeToInfraChainId(uint256 nativeChainId) public pure override returns (uint256) {

--- a/scripts/contract_extensions/GnosisChainAdapter.sol
+++ b/scripts/contract_extensions/GnosisChainAdapter.sol
@@ -18,8 +18,11 @@ contract GnosisChainAdapterTestnet is GnosisChainAdapter {
   constructor(
     address crossChainController,
     address arbitraryMessageBridge,
+    uint256 baseGasLimit,
     TrustedRemotesConfig[] memory trustedRemotes
-  ) GnosisChainAdapter(crossChainController, arbitraryMessageBridge, trustedRemotes) {}
+  )
+    GnosisChainAdapter(crossChainController, arbitraryMessageBridge, baseGasLimit, trustedRemotes)
+  {}
 
   function isDestinationChainIdSupported(uint256 chainId) public pure override returns (bool) {
     return chainId == TestNetChainIds.GNOSIS_CHIADO;

--- a/scripts/contract_extensions/LayerZeroAdapter.sol
+++ b/scripts/contract_extensions/LayerZeroAdapter.sol
@@ -25,8 +25,9 @@ contract LayerZeroAdapterTestnet is LayerZeroAdapter {
   constructor(
     address lzEndpoint,
     address crossChainController,
+    uint256 baseGasLimit,
     TrustedRemotesConfig[] memory originConfigs
-  ) LayerZeroAdapter(lzEndpoint, crossChainController, originConfigs) {}
+  ) LayerZeroAdapter(lzEndpoint, crossChainController, baseGasLimit, originConfigs) {}
 
   /// @inheritdoc IBaseAdapter
   function nativeToInfraChainId(uint256 nativeChainId) public pure override returns (uint256) {

--- a/scripts/contract_extensions/MetisAdapter.sol
+++ b/scripts/contract_extensions/MetisAdapter.sol
@@ -17,8 +17,9 @@ contract MetisAdapterTestnet is MetisAdapter {
   constructor(
     address crossChainController,
     address ovmCrossDomainMessenger,
+    uint256 baseGasLimit,
     TrustedRemotesConfig[] memory trustedRemotes
-  ) MetisAdapter(crossChainController, ovmCrossDomainMessenger, trustedRemotes) {}
+  ) MetisAdapter(crossChainController, ovmCrossDomainMessenger, baseGasLimit, trustedRemotes) {}
 
   /// @inheritdoc IOpAdapter
   function isDestinationChainIdSupported(uint256 chainId) public pure override returns (bool) {

--- a/scripts/contract_extensions/OptimismAdapter.sol
+++ b/scripts/contract_extensions/OptimismAdapter.sol
@@ -17,8 +17,9 @@ contract OptimismAdapterTestnet is OpAdapter {
   constructor(
     address crossChainController,
     address ovmCrossDomainMessenger,
+    uint256 baseGasLimit,
     TrustedRemotesConfig[] memory trustedRemotes
-  ) OpAdapter(crossChainController, ovmCrossDomainMessenger, trustedRemotes) {}
+  ) OpAdapter(crossChainController, ovmCrossDomainMessenger, baseGasLimit, trustedRemotes) {}
 
   /// @inheritdoc IOpAdapter
   function isDestinationChainIdSupported(uint256 chainId) public pure override returns (bool) {

--- a/scripts/contract_extensions/PolygonAdapterTestnets.sol
+++ b/scripts/contract_extensions/PolygonAdapterTestnets.sol
@@ -14,8 +14,9 @@ contract PolygonAdapterMumbai is PolygonAdapterBase {
   constructor(
     address crossChainController,
     address fxTunnel,
+    uint256 baseGasLimit,
     TrustedRemotesConfig[] memory trustedRemotes
-  ) PolygonAdapterBase(crossChainController, fxTunnel, trustedRemotes) {}
+  ) PolygonAdapterBase(crossChainController, fxTunnel, baseGasLimit, trustedRemotes) {}
 
   /// @inheritdoc IPolygonAdapter
   function isDestinationChainIdSupported(uint256 chainId) public pure override returns (bool) {
@@ -37,8 +38,9 @@ contract PolygonAdapterGoerli is PolygonAdapterBase {
   constructor(
     address crossChainController,
     address fxTunnel,
+    uint256 baseGasLimit,
     TrustedRemotesConfig[] memory trustedRemotes
-  ) PolygonAdapterBase(crossChainController, fxTunnel, trustedRemotes) {}
+  ) PolygonAdapterBase(crossChainController, fxTunnel, baseGasLimit, trustedRemotes) {}
 
   /// @inheritdoc IPolygonAdapter
   function isDestinationChainIdSupported(uint256 chainId) public pure override returns (bool) {

--- a/scripts/contract_extensions/ZkEVMAdapterTestnets.sol
+++ b/scripts/contract_extensions/ZkEVMAdapterTestnets.sol
@@ -8,8 +8,9 @@ contract ZkEVMAdapterGoerli is ZkEVMAdapter {
   constructor(
     address crossChainController,
     address zkEVMBridge,
+    uint256 baseGasLimit,
     TrustedRemotesConfig[] memory trustedRemotes
-  ) ZkEVMAdapter(crossChainController, zkEVMBridge, trustedRemotes) {}
+  ) ZkEVMAdapter(crossChainController, zkEVMBridge, baseGasLimit, trustedRemotes) {}
 
   function isDestinationChainIdSupported(uint256 chainId) public pure override returns (bool) {
     return chainId == TestNetChainIds.POLYGON_ZK_EVM_GOERLI;
@@ -38,8 +39,9 @@ contract ZkEVMAdapterZkEVMGoerli is ZkEVMAdapter {
   constructor(
     address crossChainController,
     address zkEVMBridge,
+    uint256 baseGasLimit,
     TrustedRemotesConfig[] memory trustedRemotes
-  ) ZkEVMAdapter(crossChainController, zkEVMBridge, trustedRemotes) {}
+  ) ZkEVMAdapter(crossChainController, zkEVMBridge, baseGasLimit, trustedRemotes) {}
 
   function isDestinationChainIdSupported(uint256 chainId) public pure override returns (bool) {
     return chainId == TestNetChainIds.ETHEREUM_GOERLI;

--- a/src/contracts/adapters/BaseAdapter.sol
+++ b/src/contracts/adapters/BaseAdapter.sol
@@ -12,7 +12,11 @@ import {Errors} from '../libs/Errors.sol';
  * @dev All bridge adapters must implement this contract
  */
 abstract contract BaseAdapter is IBaseAdapter {
+  /// @inheritdoc IBaseAdapter
   IBaseCrossChainController public immutable CROSS_CHAIN_CONTROLLER;
+
+  /// @inheritdoc IBaseAdapter
+  uint256 public immutable BASE_GAS_LIMIT;
 
   // @dev this is the original address of the contract. Required to identify and prevent delegate calls.
   address private immutable _selfAddress;
@@ -22,10 +26,18 @@ abstract contract BaseAdapter is IBaseAdapter {
 
   /**
    * @param crossChainController address of the CrossChainController the bridged messages will be routed to
+   * @param baseGasLimit base gas limit used by the bridge adapter
+   * @param originConfigs pair of origin address and chain id that adapter is allowed to get messages from
    */
-  constructor(address crossChainController, TrustedRemotesConfig[] memory originConfigs) {
+  constructor(
+    address crossChainController,
+    uint256 baseGasLimit,
+    TrustedRemotesConfig[] memory originConfigs
+  ) {
     require(crossChainController != address(0), Errors.INVALID_BASE_ADAPTER_CROSS_CHAIN_CONTROLLER);
     CROSS_CHAIN_CONTROLLER = IBaseCrossChainController(crossChainController);
+
+    BASE_GAS_LIMIT = baseGasLimit;
 
     _selfAddress = address(this);
 
@@ -43,6 +55,7 @@ abstract contract BaseAdapter is IBaseAdapter {
   /// @inheritdoc IBaseAdapter
   function infraToNativeChainId(uint256 infraChainId) public view virtual returns (uint256);
 
+  /// @inheritdoc IBaseAdapter
   function setupPayments() external virtual {}
 
   /// @inheritdoc IBaseAdapter

--- a/src/contracts/adapters/BaseAdapter.sol
+++ b/src/contracts/adapters/BaseAdapter.sol
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.8;
 
-import {IBaseAdapter} from './IBaseAdapter.sol';
-import {IBaseCrossChainController} from '../interfaces/IBaseCrossChainController.sol';
+import {IBaseAdapter, IBaseCrossChainController} from './IBaseAdapter.sol';
 import {Errors} from '../libs/Errors.sol';
 
 /**

--- a/src/contracts/adapters/IBaseAdapter.sol
+++ b/src/contracts/adapters/IBaseAdapter.sol
@@ -29,15 +29,15 @@ interface IBaseAdapter {
   /**
    * @notice method that will bridge the payload to the chain specified
    * @param receiver address of the receiver contract on destination chain
-   * @param gasLimit amount of the gas limit in wei to use for bridging on receiver side. Each adapter will manage this
-            as needed
+   * @param messageDeliveryGasLimit amount of the gas limit in wei to use for delivering the message on destination network.
+            Each adapter will manage this as needed.
    * @param destinationChainId id of the destination chain in the bridge notation
    * @param message to send to the specified chain
    * @return the third-party bridge entrypoint, the third-party bridge message id
    */
   function forwardMessage(
     address receiver,
-    uint256 gasLimit,
+    uint256 messageDeliveryGasLimit,
     uint256 destinationChainId,
     bytes calldata message
   ) external returns (address, uint256);

--- a/src/contracts/adapters/IBaseAdapter.sol
+++ b/src/contracts/adapters/IBaseAdapter.sol
@@ -41,6 +41,16 @@ interface IBaseAdapter {
   ) external returns (address, uint256);
 
   /**
+   * @notice method to get the address of the linked cross chain controller
+   */
+  function CROSS_CHAIN_CONTROLLER() external returns (address);
+
+  /**
+   * @notice method to get the base gas limit used by the bridge adapter
+   */
+  function BASE_GAS_LIMIT() external returns (uint256);
+
+  /**
    * @notice method used to setup payment, ie grant approvals over tokens used to pay for tx fees
    */
   function setupPayments() external;

--- a/src/contracts/adapters/IBaseAdapter.sol
+++ b/src/contracts/adapters/IBaseAdapter.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+import {IBaseCrossChainController} from '../interfaces/IBaseCrossChainController.sol';
+
 /**
  * @title IBaseAdapter
  * @author BGD Labs
@@ -43,7 +45,7 @@ interface IBaseAdapter {
   /**
    * @notice method to get the address of the linked cross chain controller
    */
-  function CROSS_CHAIN_CONTROLLER() external returns (address);
+  function CROSS_CHAIN_CONTROLLER() external returns (IBaseCrossChainController);
 
   /**
    * @notice method to get the base gas limit used by the bridge adapter

--- a/src/contracts/adapters/arbitrum/ArbAdapter.sol
+++ b/src/contracts/adapters/arbitrum/ArbAdapter.sol
@@ -60,7 +60,7 @@ contract ArbAdapter is IArbAdapter, BaseAdapter {
   /// @inheritdoc IBaseAdapter
   function forwardMessage(
     address receiver,
-    uint256 destinationGasLimit,
+    uint256 messageDeliveryGasLimit,
     uint256 destinationChainId,
     bytes calldata message
   ) external returns (address, uint256) {
@@ -72,13 +72,13 @@ contract ArbAdapter is IArbAdapter, BaseAdapter {
 
     bytes memory data = abi.encodeWithSelector(IArbAdapter.arbReceive.selector, message);
 
-    uint256 totalGasLimit = destinationGasLimit + BASE_GAS_LIMIT;
+    uint256 totalGasLimit = messageDeliveryGasLimit + BASE_GAS_LIMIT;
 
     (uint256 maxSubmission, uint256 maxRedemption) = getRequiredGas(data.length, totalGasLimit);
     uint256 ticketID = _forwardMessage(
       MessageInformation({
         receiver: receiver,
-        destinationGasLimit: totalGasLimit,
+        messageDeliveryGasLimit: totalGasLimit,
         encodedMessage: data,
         maxSubmission: maxSubmission,
         maxRedemption: maxRedemption
@@ -136,7 +136,7 @@ contract ArbAdapter is IArbAdapter, BaseAdapter {
         message.maxSubmission,
         DESTINATION_CCC,
         DESTINATION_CCC,
-        message.destinationGasLimit,
+        message.messageDeliveryGasLimit,
         L2_MAX_FEE_PER_GAS,
         message.encodedMessage
       );

--- a/src/contracts/adapters/arbitrum/ArbAdapter.sol
+++ b/src/contracts/adapters/arbitrum/ArbAdapter.sol
@@ -32,14 +32,16 @@ contract ArbAdapter is IArbAdapter, BaseAdapter {
   /**
    * @param crossChainController address of the cross chain controller that will use this bridge adapter
    * @param inbox arbitrum entry point address
+   * @param baseGasLimit base gas limit used by the bridge adapter
    * @param trustedRemotes list of remote configurations to set as trusted
    */
   constructor(
     address crossChainController,
     address inbox,
     address destinationCCC,
+    uint256 baseGasLimit,
     TrustedRemotesConfig[] memory trustedRemotes
-  ) BaseAdapter(crossChainController, trustedRemotes) {
+  ) BaseAdapter(crossChainController, baseGasLimit, trustedRemotes) {
     INBOX = inbox;
     DESTINATION_CCC = destinationCCC;
   }
@@ -70,14 +72,13 @@ contract ArbAdapter is IArbAdapter, BaseAdapter {
 
     bytes memory data = abi.encodeWithSelector(IArbAdapter.arbReceive.selector, message);
 
-    (uint256 maxSubmission, uint256 maxRedemption) = getRequiredGas(
-      data.length,
-      destinationGasLimit
-    );
+    uint256 totalGasLimit = destinationGasLimit + BASE_GAS_LIMIT;
+
+    (uint256 maxSubmission, uint256 maxRedemption) = getRequiredGas(data.length, totalGasLimit);
     uint256 ticketID = _forwardMessage(
       MessageInformation({
         receiver: receiver,
-        destinationGasLimit: destinationGasLimit,
+        destinationGasLimit: totalGasLimit,
         encodedMessage: data,
         maxSubmission: maxSubmission,
         maxRedemption: maxRedemption

--- a/src/contracts/adapters/arbitrum/IArbAdapter.sol
+++ b/src/contracts/adapters/arbitrum/IArbAdapter.sol
@@ -10,14 +10,14 @@ interface IArbAdapter {
   /**
    * @notice object used to store the message information
    * @param receiver address that will receive the message
-   * @param destinationGasLimit max gas limit to be used on destination chain
+   * @param messageDeliveryGasLimit max gas limit to be used on destination chain
    * @param maxSubmission gas required for ticket submission
    * @param maxRedemption gas required for ticket redemption
    * @param encodedMessage calldata used on destination chain
    */
   struct MessageInformation {
     address receiver;
-    uint256 destinationGasLimit;
+    uint256 messageDeliveryGasLimit;
     uint256 maxSubmission;
     uint256 maxRedemption;
     bytes encodedMessage;

--- a/src/contracts/adapters/cBase/CBaseAdapter.sol
+++ b/src/contracts/adapters/cBase/CBaseAdapter.sol
@@ -19,13 +19,15 @@ contract CBaseAdapter is OpAdapter {
   /**
    * @param crossChainController address of the cross chain controller that will use this bridge adapter
    * @param ovmCrossDomainMessenger optimism entry point address
+   * @param baseGasLimit base gas limit used by the bridge adapter
    * @param trustedRemotes list of remote configurations to set as trusted
    */
   constructor(
     address crossChainController,
     address ovmCrossDomainMessenger,
+    uint256 baseGasLimit,
     TrustedRemotesConfig[] memory trustedRemotes
-  ) OpAdapter(crossChainController, ovmCrossDomainMessenger, trustedRemotes) {}
+  ) OpAdapter(crossChainController, ovmCrossDomainMessenger, baseGasLimit, trustedRemotes) {}
 
   /// @inheritdoc IOpAdapter
   function isDestinationChainIdSupported(

--- a/src/contracts/adapters/ccip/CCIPAdapter.sol
+++ b/src/contracts/adapters/ccip/CCIPAdapter.sol
@@ -39,15 +39,17 @@ contract CCIPAdapter is ICCIPAdapter, BaseAdapter, IAny2EVMMessageReceiver, IERC
   /**
    * @param crossChainController address of the cross chain controller that will use this bridge adapter
    * @param ccipRouter ccip entry point address
+   * @param baseGasLimit base gas limit used by the bridge adapter
    * @param trustedRemotes list of remote configurations to set as trusted
    * @param linkToken address of the erc20 LINK token
    */
   constructor(
     address crossChainController,
     address ccipRouter,
+    uint256 baseGasLimit,
     TrustedRemotesConfig[] memory trustedRemotes,
     address linkToken
-  ) BaseAdapter(crossChainController, trustedRemotes) {
+  ) BaseAdapter(crossChainController, baseGasLimit, trustedRemotes) {
     require(ccipRouter != address(0), Errors.CCIP_ROUTER_CANT_BE_ADDRESS_0);
     require(linkToken != address(0), Errors.LINK_TOKEN_CANT_BE_ADDRESS_0);
     CCIP_ROUTER = IRouterClient(ccipRouter);
@@ -72,8 +74,10 @@ contract CCIPAdapter is ICCIPAdapter, BaseAdapter, IAny2EVMMessageReceiver, IERC
     require(CCIP_ROUTER.isChainSupported(nativeChainId), Errors.DESTINATION_CHAIN_ID_NOT_SUPPORTED);
     require(receiver != address(0), Errors.RECEIVER_NOT_SET);
 
+    uint256 totalGasLimit = destinationGasLimit + BASE_GAS_LIMIT;
+
     Client.EVMExtraArgsV1 memory evmExtraArgs = Client.EVMExtraArgsV1({
-      gasLimit: destinationGasLimit,
+      gasLimit: totalGasLimit,
       strict: false
     });
 

--- a/src/contracts/adapters/ccip/CCIPAdapter.sol
+++ b/src/contracts/adapters/ccip/CCIPAdapter.sol
@@ -66,7 +66,7 @@ contract CCIPAdapter is ICCIPAdapter, BaseAdapter, IAny2EVMMessageReceiver, IERC
   /// @inheritdoc IBaseAdapter
   function forwardMessage(
     address receiver,
-    uint256 destinationGasLimit,
+    uint256 messageDeliveryGasLimit,
     uint256 destinationChainId,
     bytes calldata message
   ) external returns (address, uint256) {
@@ -74,7 +74,7 @@ contract CCIPAdapter is ICCIPAdapter, BaseAdapter, IAny2EVMMessageReceiver, IERC
     require(CCIP_ROUTER.isChainSupported(nativeChainId), Errors.DESTINATION_CHAIN_ID_NOT_SUPPORTED);
     require(receiver != address(0), Errors.RECEIVER_NOT_SET);
 
-    uint256 totalGasLimit = destinationGasLimit + BASE_GAS_LIMIT;
+    uint256 totalGasLimit = messageDeliveryGasLimit + BASE_GAS_LIMIT;
 
     Client.EVMExtraArgsV1 memory evmExtraArgs = Client.EVMExtraArgsV1({
       gasLimit: totalGasLimit,

--- a/src/contracts/adapters/gnosisChain/GnosisChainAdapter.sol
+++ b/src/contracts/adapters/gnosisChain/GnosisChainAdapter.sol
@@ -38,7 +38,7 @@ contract GnosisChainAdapter is BaseAdapter, IGnosisChainAdapter {
   /// @inheritdoc IBaseAdapter
   function forwardMessage(
     address receiver,
-    uint256 destinationGasLimit,
+    uint256 messageDeliveryGasLimit,
     uint256 destinationChainId,
     bytes calldata message
   ) external override returns (address, uint256) {
@@ -50,7 +50,7 @@ contract GnosisChainAdapter is BaseAdapter, IGnosisChainAdapter {
 
     bytes memory data = abi.encodeWithSelector(this.receiveMessage.selector, message);
 
-    uint256 totalGasLimit = destinationGasLimit + BASE_GAS_LIMIT;
+    uint256 totalGasLimit = messageDeliveryGasLimit + BASE_GAS_LIMIT;
 
     IArbitraryMessageBridge(BRIDGE).requireToPassMessage(receiver, data, totalGasLimit);
     return (address(BRIDGE), 0);

--- a/src/contracts/adapters/hyperLane/HyperLaneAdapter.sol
+++ b/src/contracts/adapters/hyperLane/HyperLaneAdapter.sol
@@ -33,14 +33,16 @@ contract HyperLaneAdapter is BaseAdapter, IHyperLaneAdapter, IMessageRecipient {
    * @param crossChainController address of the cross chain controller that will use this bridge adapter
    * @param mailBox HyperLane router contract address to send / receive cross chain messages
    * @param igp HyperLane contract to get the gas estimation to pay for sending messages
+   * @param baseGasLimit base gas limit used by the bridge adapter
    * @param trustedRemotes list of remote configurations to set as trusted
    */
   constructor(
     address crossChainController,
     address mailBox,
     address igp,
+    uint256 baseGasLimit,
     TrustedRemotesConfig[] memory trustedRemotes
-  ) BaseAdapter(crossChainController, trustedRemotes) {
+  ) BaseAdapter(crossChainController, baseGasLimit, trustedRemotes) {
     HL_MAIL_BOX = IMailbox(mailBox);
     IGP = IInterchainGasPaymaster(igp);
   }
@@ -62,8 +64,10 @@ contract HyperLaneAdapter is BaseAdapter, IHyperLaneAdapter, IMessageRecipient {
       message
     );
 
+    uint256 totalGasLimit = destinationGasLimit + BASE_GAS_LIMIT;
+
     // Get the required payment from the IGP.
-    uint256 quotedPayment = IGP.quoteGasPayment(nativeChainId, destinationGasLimit);
+    uint256 quotedPayment = IGP.quoteGasPayment(nativeChainId, totalGasLimit);
 
     require(quotedPayment <= address(this).balance, Errors.NOT_ENOUGH_VALUE_TO_PAY_BRIDGE_FEES);
 
@@ -71,7 +75,7 @@ contract HyperLaneAdapter is BaseAdapter, IHyperLaneAdapter, IMessageRecipient {
     IGP.payForGas{value: quotedPayment}(
       messageId, // The ID of the message that was just dispatched
       nativeChainId, // The destination domain of the message
-      destinationGasLimit,
+      totalGasLimit,
       address(this) // refunds go to CrossChainController, who paid the msg.value
     );
 

--- a/src/contracts/adapters/hyperLane/HyperLaneAdapter.sol
+++ b/src/contracts/adapters/hyperLane/HyperLaneAdapter.sol
@@ -50,7 +50,7 @@ contract HyperLaneAdapter is BaseAdapter, IHyperLaneAdapter, IMessageRecipient {
   /// @inheritdoc IBaseAdapter
   function forwardMessage(
     address receiver,
-    uint256 destinationGasLimit,
+    uint256 messageDeliveryGasLimit,
     uint256 destinationChainId,
     bytes calldata message
   ) external returns (address, uint256) {
@@ -64,7 +64,7 @@ contract HyperLaneAdapter is BaseAdapter, IHyperLaneAdapter, IMessageRecipient {
       message
     );
 
-    uint256 totalGasLimit = destinationGasLimit + BASE_GAS_LIMIT;
+    uint256 totalGasLimit = messageDeliveryGasLimit + BASE_GAS_LIMIT;
 
     // Get the required payment from the IGP.
     uint256 quotedPayment = IGP.quoteGasPayment(nativeChainId, totalGasLimit);

--- a/src/contracts/adapters/layerZero/LayerZeroAdapter.sol
+++ b/src/contracts/adapters/layerZero/LayerZeroAdapter.sol
@@ -67,7 +67,7 @@ contract LayerZeroAdapter is BaseAdapter, ILayerZeroAdapter, ILayerZeroReceiver 
   /// @inheritdoc IBaseAdapter
   function forwardMessage(
     address receiver,
-    uint256 destinationGasLimit,
+    uint256 messageDeliveryGasLimit,
     uint256 destinationChainId,
     bytes calldata message
   ) external returns (address, uint256) {
@@ -75,7 +75,7 @@ contract LayerZeroAdapter is BaseAdapter, ILayerZeroAdapter, ILayerZeroReceiver 
     require(nativeChainId != uint16(0), Errors.DESTINATION_CHAIN_ID_NOT_SUPPORTED);
     require(receiver != address(0), Errors.RECEIVER_NOT_SET);
 
-    uint256 totalGasLimit = destinationGasLimit + BASE_GAS_LIMIT;
+    uint256 totalGasLimit = messageDeliveryGasLimit + BASE_GAS_LIMIT;
 
     bytes memory adapterParams = abi.encodePacked(VERSION, totalGasLimit);
 

--- a/src/contracts/adapters/metis/MetisAdapter.sol
+++ b/src/contracts/adapters/metis/MetisAdapter.sol
@@ -19,13 +19,15 @@ contract MetisAdapter is OpAdapter {
   /**
    * @param crossChainController address of the cross chain controller that will use this bridge adapter
    * @param ovmCrossDomainMessenger optimism entry point address
+   * @param baseGasLimit base gas limit used by the bridge adapter
    * @param trustedRemotes list of remote configurations to set as trusted
    */
   constructor(
     address crossChainController,
     address ovmCrossDomainMessenger,
+    uint256 baseGasLimit,
     TrustedRemotesConfig[] memory trustedRemotes
-  ) OpAdapter(crossChainController, ovmCrossDomainMessenger, trustedRemotes) {}
+  ) OpAdapter(crossChainController, ovmCrossDomainMessenger, baseGasLimit, trustedRemotes) {}
 
   /// @inheritdoc IOpAdapter
   function isDestinationChainIdSupported(
@@ -52,11 +54,13 @@ contract MetisAdapter is OpAdapter {
     );
     require(receiver != address(0), Errors.RECEIVER_NOT_SET);
 
+    uint256 totalGasLimit = destinationGasLimit + BASE_GAS_LIMIT;
+
     ICrossDomainMessenger(OVM_CROSS_DOMAIN_MESSENGER).sendMessageViaChainId(
       destinationChainId,
       receiver,
       abi.encodeWithSelector(IOpAdapter.ovmReceive.selector, message),
-      SafeCast.toUint32(destinationGasLimit) // for now gas fees are paid on optimism ( < 1.9) and metis (<5M) but its subject to change
+      SafeCast.toUint32(totalGasLimit) // for now gas fees are paid on optimism ( < 1.9) and metis (<5M) but its subject to change
     );
 
     return (OVM_CROSS_DOMAIN_MESSENGER, 0);

--- a/src/contracts/adapters/metis/MetisAdapter.sol
+++ b/src/contracts/adapters/metis/MetisAdapter.sol
@@ -44,7 +44,7 @@ contract MetisAdapter is OpAdapter {
   /// @inheritdoc IBaseAdapter
   function forwardMessage(
     address receiver,
-    uint256 destinationGasLimit,
+    uint256 messageDeliveryGasLimit,
     uint256 destinationChainId,
     bytes calldata message
   ) external override returns (address, uint256) {
@@ -54,7 +54,7 @@ contract MetisAdapter is OpAdapter {
     );
     require(receiver != address(0), Errors.RECEIVER_NOT_SET);
 
-    uint256 totalGasLimit = destinationGasLimit + BASE_GAS_LIMIT;
+    uint256 totalGasLimit = messageDeliveryGasLimit + BASE_GAS_LIMIT;
 
     ICrossDomainMessenger(OVM_CROSS_DOMAIN_MESSENGER).sendMessageViaChainId(
       destinationChainId,

--- a/src/contracts/adapters/optimism/OpAdapter.sol
+++ b/src/contracts/adapters/optimism/OpAdapter.sol
@@ -46,7 +46,7 @@ contract OpAdapter is IOpAdapter, BaseAdapter {
   /// @inheritdoc IBaseAdapter
   function forwardMessage(
     address receiver,
-    uint256 destinationGasLimit,
+    uint256 messageDeliveryGasLimit,
     uint256 destinationChainId,
     bytes calldata message
   ) external virtual returns (address, uint256) {
@@ -56,7 +56,7 @@ contract OpAdapter is IOpAdapter, BaseAdapter {
     );
     require(receiver != address(0), Errors.RECEIVER_NOT_SET);
 
-    uint256 totalGasLimit = destinationGasLimit + BASE_GAS_LIMIT;
+    uint256 totalGasLimit = messageDeliveryGasLimit + BASE_GAS_LIMIT;
 
     ICrossDomainMessenger(OVM_CROSS_DOMAIN_MESSENGER).sendMessage(
       receiver,

--- a/src/contracts/adapters/optimism/OpAdapter.sol
+++ b/src/contracts/adapters/optimism/OpAdapter.sol
@@ -31,13 +31,15 @@ contract OpAdapter is IOpAdapter, BaseAdapter {
   /**
    * @param crossChainController address of the cross chain controller that will use this bridge adapter
    * @param ovmCrossDomainMessenger optimism entry point address
+   * @param baseGasLimit base gas limit used by the bridge adapter
    * @param trustedRemotes list of remote configurations to set as trusted
    */
   constructor(
     address crossChainController,
     address ovmCrossDomainMessenger,
+    uint256 baseGasLimit,
     TrustedRemotesConfig[] memory trustedRemotes
-  ) BaseAdapter(crossChainController, trustedRemotes) {
+  ) BaseAdapter(crossChainController, baseGasLimit, trustedRemotes) {
     OVM_CROSS_DOMAIN_MESSENGER = ovmCrossDomainMessenger;
   }
 
@@ -54,10 +56,12 @@ contract OpAdapter is IOpAdapter, BaseAdapter {
     );
     require(receiver != address(0), Errors.RECEIVER_NOT_SET);
 
+    uint256 totalGasLimit = destinationGasLimit + BASE_GAS_LIMIT;
+
     ICrossDomainMessenger(OVM_CROSS_DOMAIN_MESSENGER).sendMessage(
       receiver,
       abi.encodeWithSelector(IOpAdapter.ovmReceive.selector, message),
-      SafeCast.toUint32(destinationGasLimit) // for now gas fees are paid on optimism ( < 1.9) and metis (<5M) but its subject to change
+      SafeCast.toUint32(totalGasLimit) // for now gas fees are paid on optimism ( < 1.9) and metis (<5M) but its subject to change
     );
 
     return (OVM_CROSS_DOMAIN_MESSENGER, 0);

--- a/src/contracts/adapters/polygon/PolygonAdapterBase.sol
+++ b/src/contracts/adapters/polygon/PolygonAdapterBase.sol
@@ -26,13 +26,15 @@ abstract contract PolygonAdapterBase is IPolygonAdapter, IFxMessageProcessor, Ba
   /**
    * @param crossChainController address of the cross chain controller that will use this bridge adapter
    * @param fxTunnel address of the fx tunnel that will be used to send/receive messages to the root/child chain
+   * @param baseGasLimit base gas limit used by the bridge adapter
    * @param trustedRemotes list of remote configurations to set as trusted
    */
   constructor(
     address crossChainController,
     address fxTunnel,
+    uint256 baseGasLimit,
     TrustedRemotesConfig[] memory trustedRemotes
-  ) BaseAdapter(crossChainController, trustedRemotes) {
+  ) BaseAdapter(crossChainController, baseGasLimit, trustedRemotes) {
     FX_TUNNEL = fxTunnel;
   }
 

--- a/src/contracts/adapters/polygon/PolygonAdapterEthereum.sol
+++ b/src/contracts/adapters/polygon/PolygonAdapterEthereum.sol
@@ -8,8 +8,9 @@ contract PolygonAdapterEthereum is PolygonAdapterBase {
   constructor(
     address crossChainController,
     address fxTunnel,
+    uint256 baseGasLimit,
     TrustedRemotesConfig[] memory trustedRemotes
-  ) PolygonAdapterBase(crossChainController, fxTunnel, trustedRemotes) {}
+  ) PolygonAdapterBase(crossChainController, fxTunnel, baseGasLimit, trustedRemotes) {}
 
   // Overrides to use the Polygon chain id, which is Ethereum's origin
   function getOriginChainId() public pure override returns (uint256) {

--- a/src/contracts/adapters/polygon/PolygonAdapterPolygon.sol
+++ b/src/contracts/adapters/polygon/PolygonAdapterPolygon.sol
@@ -8,8 +8,9 @@ contract PolygonAdapterPolygon is PolygonAdapterBase {
   constructor(
     address crossChainController,
     address fxTunnel,
+    uint256 baseGasLimit,
     TrustedRemotesConfig[] memory trustedRemotes
-  ) PolygonAdapterBase(crossChainController, fxTunnel, trustedRemotes) {}
+  ) PolygonAdapterBase(crossChainController, fxTunnel, baseGasLimit, trustedRemotes) {}
 
   // Overrides to use Ethereum chain id, which is Polygon's origin
   function getOriginChainId() public pure override returns (uint256) {

--- a/src/contracts/adapters/sameChain/SameChainAdapter.sol
+++ b/src/contracts/adapters/sameChain/SameChainAdapter.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.8;
 
-import {IBaseAdapter} from '../IBaseAdapter.sol';
+import {IBaseAdapter, IBaseCrossChainController} from '../IBaseAdapter.sol';
 import {IBaseReceiverPortal} from '../../interfaces/IBaseReceiverPortal.sol';
 import {Errors} from '../../libs/Errors.sol';
 import {Transaction, Envelope, TransactionUtils} from '../../libs/EncodingUtils.sol';
@@ -14,6 +14,16 @@ import {Transaction, Envelope, TransactionUtils} from '../../libs/EncodingUtils.
            that the message is forwarded to same chain
  */
 contract SameChainAdapter is IBaseAdapter {
+  /// @inheritdoc IBaseAdapter
+  function CROSS_CHAIN_CONTROLLER() external returns (IBaseCrossChainController) {
+    return IBaseCrossChainController(address(0));
+  }
+
+  /// @inheritdoc IBaseAdapter
+  function BASE_GAS_LIMIT() external returns (uint256) {
+    return 0;
+  }
+
   /// @inheritdoc IBaseAdapter
   function forwardMessage(
     address,

--- a/src/contracts/adapters/zkEVM/ZkEVMAdapter.sol
+++ b/src/contracts/adapters/zkEVM/ZkEVMAdapter.sol
@@ -26,13 +26,15 @@ abstract contract ZkEVMAdapter is BaseAdapter, IBridgeMessageReceiver {
   /**
    * @param crossChainController address of the cross chain controller that will use this bridge adapter
    * @param zkEVMBridge address of the zkEVMBridge that will be used to send/receive messages to the root/child chain
+   * @param baseGasLimit base gas limit used by the bridge adapter
    * @param trustedRemotes list of remote configurations to set as trusted
    */
   constructor(
     address crossChainController,
     address zkEVMBridge,
+    uint256 baseGasLimit,
     TrustedRemotesConfig[] memory trustedRemotes
-  ) BaseAdapter(crossChainController, trustedRemotes) {
+  ) BaseAdapter(crossChainController, baseGasLimit, trustedRemotes) {
     ZK_EVM_BRIDGE = zkEVMBridge;
   }
 

--- a/src/contracts/adapters/zkEVM/ZkEVMAdapterEthereum.sol
+++ b/src/contracts/adapters/zkEVM/ZkEVMAdapterEthereum.sol
@@ -13,11 +13,13 @@ contract ZkEVMAdapterEthereum is ZkEVMAdapter {
   /**
    * @param crossChainController address of the cross chain controller that will use this bridge adapter
    * @param zkEVMBridge address of the zkEVMBridge that will be used to send/receive messages to the root/child chain
+   * @param baseGasLimit base gas limit used by the bridge adapter
    * @param trustedRemotes list of remote configurations to set as trusted
    */
   constructor(
     address crossChainController,
     address zkEVMBridge,
+    uint256 baseGasLimit,
     TrustedRemotesConfig[] memory trustedRemotes
-  ) ZkEVMAdapter(crossChainController, zkEVMBridge, trustedRemotes) {}
+  ) ZkEVMAdapter(crossChainController, zkEVMBridge, baseGasLimit, trustedRemotes) {}
 }

--- a/src/contracts/adapters/zkEVM/ZkEVMAdapterPolygonZkEVM.sol
+++ b/src/contracts/adapters/zkEVM/ZkEVMAdapterPolygonZkEVM.sol
@@ -13,11 +13,13 @@ contract ZkEVMAdapterPolygonZkEVM is ZkEVMAdapter {
   /**
    * @param crossChainController address of the cross chain controller that will use this bridge adapter
    * @param zkEVMBridge address of the zkEVMBridge that will be used to send/receive messages to the root/child chain
+   * @param baseGasLimit base gas limit used by the bridge adapter
    * @param trustedRemotes list of remote configurations to set as trusted
    */
   constructor(
     address crossChainController,
     address zkEVMBridge,
+    uint256 baseGasLimit,
     TrustedRemotesConfig[] memory trustedRemotes
-  ) ZkEVMAdapter(crossChainController, zkEVMBridge, trustedRemotes) {}
+  ) ZkEVMAdapter(crossChainController, zkEVMBridge, baseGasLimit, trustedRemotes) {}
 }

--- a/tests/CrossChainForwarder.t.sol
+++ b/tests/CrossChainForwarder.t.sol
@@ -65,7 +65,7 @@ contract CrossChainForwarderTest is BaseTest {
       memory originConfigs = new LayerZeroAdapter.TrustedRemotesConfig[](1);
     originConfigs[0] = originConfig;
 
-    lzAdapter = new LayerZeroAdapter(LZ_ENDPOINT, address(crossChainForwarder), originConfigs);
+    lzAdapter = new LayerZeroAdapter(LZ_ENDPOINT, address(crossChainForwarder), 0, originConfigs);
 
     ICrossChainForwarder.ForwarderBridgeAdapterConfigInput[]
       memory bridgeAdaptersToAllow = new ICrossChainForwarder.ForwarderBridgeAdapterConfigInput[](

--- a/tests/adapters/ArbAdapter.t.sol
+++ b/tests/adapters/ArbAdapter.t.sol
@@ -16,6 +16,8 @@ contract ArbAdapterTest is Test {
   uint256 public constant ORIGIN_CHAIN_ID = ChainIds.ETHEREUM;
   address public constant ADDRESS_WITH_ETH = address(12301234);
 
+  uint256 public constant BASE_GAS_LIMIT = 10_000;
+
   ArbAdapter public arbAdapter;
 
   IBaseAdapter.TrustedRemotesConfig internal originConfig =
@@ -33,6 +35,7 @@ contract ArbAdapterTest is Test {
       CROSS_CHAIN_CONTROLLER,
       INBOX,
       RECEIVER_CROSS_CHAIN_CONTROLLER,
+      BASE_GAS_LIMIT,
       originConfigs
     );
   }
@@ -75,7 +78,7 @@ contract ArbAdapterTest is Test {
         maxSubmission,
         RECEIVER_CROSS_CHAIN_CONTROLLER,
         RECEIVER_CROSS_CHAIN_CONTROLLER,
-        dstGasLimit,
+        dstGasLimit + BASE_GAS_LIMIT,
         arbAdapter.L2_MAX_FEE_PER_GAS(),
         data
       ),

--- a/tests/adapters/BaseAdapter.t.sol
+++ b/tests/adapters/BaseAdapter.t.sol
@@ -8,8 +8,9 @@ import {Errors} from '../../src/contracts/libs/Errors.sol';
 contract MockAdapter is BaseAdapter {
   constructor(
     address crossChainController,
+    uint256 baseGasLimit,
     TrustedRemotesConfig[] memory trustedRemotes
-  ) BaseAdapter(crossChainController, trustedRemotes) {}
+  ) BaseAdapter(crossChainController, baseGasLimit, trustedRemotes) {}
 
   function forwardMessage(
     address,
@@ -34,6 +35,6 @@ contract BaseAdapterTest is Test {
 
   function testContractCreationWhenAddress0() public {
     vm.expectRevert(bytes(Errors.INVALID_BASE_ADAPTER_CROSS_CHAIN_CONTROLLER));
-    new MockAdapter(address(0), new IBaseAdapter.TrustedRemotesConfig[](1));
+    new MockAdapter(address(0), 0, new IBaseAdapter.TrustedRemotesConfig[](1));
   }
 }

--- a/tests/adapters/CCIPAdapter.t.sol
+++ b/tests/adapters/CCIPAdapter.t.sol
@@ -18,6 +18,8 @@ contract CCIPAdapterTest is Test {
 
   uint256 public constant ORIGIN_CCIP_CHAIN_ID = ChainIds.ETHEREUM;
 
+  uint256 public constant BASE_GAS_LIMIT = 10_000;
+
   IERC20 public LINK_TOKEN;
 
   IBaseAdapter.TrustedRemotesConfig internal originConfig =
@@ -39,6 +41,7 @@ contract CCIPAdapterTest is Test {
     ccipAdapter = new CCIPAdapter(
       CROSS_CHAIN_CONTROLLER,
       CCIP_ROUTER,
+      BASE_GAS_LIMIT,
       originConfigs,
       address(LINK_TOKEN)
     );

--- a/tests/adapters/GnosisChainAdapter.t.sol
+++ b/tests/adapters/GnosisChainAdapter.t.sol
@@ -19,6 +19,8 @@ contract GnosisChainAdapterTest is Test {
 
   GnosisChainAdapter public gnosisChainAdapter;
 
+  uint256 public constant BASE_GAS_LIMIT = 10_000;
+
   IBaseAdapter.TrustedRemotesConfig internal originConfig =
     IBaseAdapter.TrustedRemotesConfig({
       originForwarder: ORIGIN_FORWARDER,
@@ -33,6 +35,7 @@ contract GnosisChainAdapterTest is Test {
     gnosisChainAdapter = new GnosisChainAdapter(
       CROSS_CHAIN_CONTROLLER,
       GNOSIS_AMB_BRIDGE,
+      BASE_GAS_LIMIT,
       originConfigs
     );
   }
@@ -54,6 +57,7 @@ contract GnosisChainAdapterTest is Test {
     gnosisChainAdapter = new GnosisChainAdapter(
       CROSS_CHAIN_CONTROLLER,
       address(0),
+      BASE_GAS_LIMIT,
       new IBaseAdapter.TrustedRemotesConfig[](0)
     );
   }
@@ -70,7 +74,7 @@ contract GnosisChainAdapterTest is Test {
         IArbitraryMessageBridge.requireToPassMessage.selector,
         RECEIVER_CROSS_CHAIN_CONTROLLER,
         abi.encodeWithSelector(IGnosisChainAdapter.receiveMessage.selector, message),
-        dstGasLimit
+        dstGasLimit + BASE_GAS_LIMIT
       ),
       abi.encode(bytes32(uint256(uint160(RECEIVER_CROSS_CHAIN_CONTROLLER))))
     );

--- a/tests/adapters/HyperLaneAdapter.t.sol
+++ b/tests/adapters/HyperLaneAdapter.t.sol
@@ -18,6 +18,7 @@ contract HyperLaneAdapterTest is Test {
   address public constant ADDRESS_WITH_ETH = address(12301234);
 
   uint256 public constant ORIGIN_HL_CHAIN_ID = ChainIds.ETHEREUM;
+  uint256 public constant BASE_GAS_LIMIT = 10_000;
 
   HyperLaneAdapter public hlAdapter;
 
@@ -34,7 +35,13 @@ contract HyperLaneAdapterTest is Test {
       memory originConfigs = new IBaseAdapter.TrustedRemotesConfig[](1);
     originConfigs[0] = originConfig;
 
-    hlAdapter = new HyperLaneAdapter(CROSS_CHAIN_CONTROLLER, MAIL_BOX, IGP, originConfigs);
+    hlAdapter = new HyperLaneAdapter(
+      CROSS_CHAIN_CONTROLLER,
+      MAIL_BOX,
+      IGP,
+      BASE_GAS_LIMIT,
+      originConfigs
+    );
   }
 
   function testInitialize() public {
@@ -67,7 +74,7 @@ contract HyperLaneAdapterTest is Test {
       abi.encodeWithSelector(
         IInterchainGasPaymaster.quoteGasPayment.selector,
         nativeChainId,
-        dstGasLimit
+        dstGasLimit + BASE_GAS_LIMIT
       ),
       abi.encode(10)
     );
@@ -78,7 +85,7 @@ contract HyperLaneAdapterTest is Test {
         IInterchainGasPaymaster.payForGas.selector,
         messageId,
         nativeChainId,
-        dstGasLimit,
+        dstGasLimit + BASE_GAS_LIMIT,
         ADDRESS_WITH_ETH
       ),
       abi.encode()

--- a/tests/adapters/LayerZeroAdapter.t.sol
+++ b/tests/adapters/LayerZeroAdapter.t.sol
@@ -18,6 +18,7 @@ contract LayerZeroAdapterTest is Test {
   address public constant RECEIVER_CROSS_CHAIN_CONTROLLER = address(12345678);
   address public constant ADDRESS_WITH_ETH = address(12301234);
   uint16 public constant BRIDGE_CHAIN_ID = uint16(109);
+  uint256 public constant BASE_GAS_LIMIT = 10_000;
 
   LayerZeroAdapter layerZeroAdapter;
 
@@ -32,7 +33,12 @@ contract LayerZeroAdapterTest is Test {
       memory originConfigs = new IBaseAdapter.TrustedRemotesConfig[](1);
     originConfigs[0] = originConfig;
 
-    layerZeroAdapter = new LayerZeroAdapter(LZ_ENDPOINT, CROSS_CHAIN_CONTROLLER, originConfigs);
+    layerZeroAdapter = new LayerZeroAdapter(
+      LZ_ENDPOINT,
+      CROSS_CHAIN_CONTROLLER,
+      BASE_GAS_LIMIT,
+      originConfigs
+    );
   }
 
   function testAddressToBytes() public {

--- a/tests/adapters/MetisAdapter.t.sol
+++ b/tests/adapters/MetisAdapter.t.sol
@@ -17,6 +17,7 @@ contract MetisAdapterTest is Test {
   address public constant RECEIVER_CROSS_CHAIN_CONTROLLER = address(1234567);
   uint256 public constant ORIGIN_CHAIN_ID = ChainIds.ETHEREUM;
   address public constant ADDRESS_WITH_ETH = address(12301234);
+  uint256 public constant BASE_GAS_LIMIT = 10_000;
 
   MetisAdapter public metisAdapter;
 
@@ -34,6 +35,7 @@ contract MetisAdapterTest is Test {
     metisAdapter = new MetisAdapter(
       CROSS_CHAIN_CONTROLLER,
       OVM_CROSS_DOMAIN_MESSENGER,
+      BASE_GAS_LIMIT,
       originConfigs
     );
   }
@@ -62,7 +64,7 @@ contract MetisAdapterTest is Test {
         ICrossDomainMessenger.sendMessage.selector,
         RECEIVER_CROSS_CHAIN_CONTROLLER,
         abi.encodeWithSelector(IOpAdapter.ovmReceive.selector, message),
-        SafeCast.toUint32(dstGasLimit)
+        SafeCast.toUint32(dstGasLimit + BASE_GAS_LIMIT)
       ),
       abi.encode()
     );

--- a/tests/adapters/OpAdapter.t.sol
+++ b/tests/adapters/OpAdapter.t.sol
@@ -16,6 +16,7 @@ contract OpAdapterTest is Test {
   address public constant RECEIVER_CROSS_CHAIN_CONTROLLER = address(1234567);
   uint256 public constant ORIGIN_CHAIN_ID = ChainIds.ETHEREUM;
   address public constant ADDRESS_WITH_ETH = address(12301234);
+  uint256 public constant BASE_GAS_LIMIT = 10_000;
 
   OpAdapter public opAdapter;
 
@@ -30,7 +31,12 @@ contract OpAdapterTest is Test {
       memory originConfigs = new IBaseAdapter.TrustedRemotesConfig[](1);
     originConfigs[0] = originConfig;
 
-    opAdapter = new OpAdapter(CROSS_CHAIN_CONTROLLER, OVM_CROSS_DOMAIN_MESSENGER, originConfigs);
+    opAdapter = new OpAdapter(
+      CROSS_CHAIN_CONTROLLER,
+      OVM_CROSS_DOMAIN_MESSENGER,
+      BASE_GAS_LIMIT,
+      originConfigs
+    );
   }
 
   function testInitialize() public {
@@ -57,7 +63,7 @@ contract OpAdapterTest is Test {
         ICrossDomainMessenger.sendMessage.selector,
         RECEIVER_CROSS_CHAIN_CONTROLLER,
         abi.encodeWithSelector(IOpAdapter.ovmReceive.selector, message),
-        SafeCast.toUint32(dstGasLimit)
+        SafeCast.toUint32(dstGasLimit + BASE_GAS_LIMIT)
       ),
       abi.encode()
     );

--- a/tests/adapters/PolygonAdapter.t.sol
+++ b/tests/adapters/PolygonAdapter.t.sol
@@ -19,6 +19,7 @@ contract PolygonAdapterTest is Test {
   uint256 public constant ORIGIN_CHAIN_ID = ChainIds.ETHEREUM;
   uint256 public constant DESTINATION_CHAIN_ID = ChainIds.POLYGON;
   address public constant ADDRESS_WITH_ETH = address(12301234);
+  uint256 public constant BASE_GAS_LIMIT = 10_000;
 
   PolygonAdapterEthereum public polygonAdapterEthereum;
   PolygonAdapterPolygon public polygonAdapterPolygon;
@@ -43,6 +44,7 @@ contract PolygonAdapterTest is Test {
     polygonAdapterEthereum = new PolygonAdapterEthereum(
       CROSS_CHAIN_CONTROLLER,
       FX_TUNNEL_ETHEREUM,
+      BASE_GAS_LIMIT,
       originConfigsEthereum
     );
 
@@ -53,6 +55,7 @@ contract PolygonAdapterTest is Test {
     polygonAdapterPolygon = new PolygonAdapterPolygon(
       CROSS_CHAIN_CONTROLLER,
       FX_TUNNEL_POLYGON,
+      BASE_GAS_LIMIT,
       originConfigsPolygon
     );
   }

--- a/tests/adapters/ZkEvmAdapter.t.sol
+++ b/tests/adapters/ZkEvmAdapter.t.sol
@@ -18,6 +18,7 @@ contract ZkEvmAdapterTest is Test {
   uint256 public constant ORIGIN_CHAIN_ID = ChainIds.ETHEREUM;
   uint256 public constant DESTINATION_CHAIN_ID = ChainIds.POLYGON_ZK_EVM;
   address public constant ADDRESS_WITH_ETH = address(12301234);
+  uint256 public constant BASE_GAS_LIMIT = 10_000;
 
   ZkEVMAdapterEthereum public zkEvmAdapterEthereum;
   ZkEVMAdapterPolygonZkEVM public zkEvmAdapterPolygonZkEvm;
@@ -35,6 +36,7 @@ contract ZkEvmAdapterTest is Test {
     zkEvmAdapterEthereum = new ZkEVMAdapterEthereum(
       CROSS_CHAIN_CONTROLLER,
       ZK_EVM_BRIDGE,
+      BASE_GAS_LIMIT,
       originConfigsEthereum
     );
 
@@ -45,6 +47,7 @@ contract ZkEvmAdapterTest is Test {
     zkEvmAdapterPolygonZkEvm = new ZkEVMAdapterPolygonZkEVM(
       RECEIVER_CROSS_CHAIN_CONTROLLER,
       ZK_EVM_BRIDGE,
+      BASE_GAS_LIMIT,
       originConfigsPolygon
     );
   }

--- a/tests/mocks/FailingAdapter.sol
+++ b/tests/mocks/FailingAdapter.sol
@@ -6,7 +6,7 @@ import {BaseAdapter, IBaseAdapter} from '../../src/contracts/adapters/BaseAdapte
 contract FailingAdapter is BaseAdapter {
   constructor(
     TrustedRemotesConfig[] memory trustedRemotes
-  ) BaseAdapter(address(1), trustedRemotes) {}
+  ) BaseAdapter(address(1), 0, trustedRemotes) {}
 
   /// @inheritdoc IBaseAdapter
   function forwardMessage(


### PR DESCRIPTION
Added base gas limit to the base adapter, so that we can granullary have different gas amounts for each network and underlying bridge

refactored destinationGasLimit naming to messageDeliveryGasLimit