### PR TITLE
fix: Add event for when a tx is received but message already confirmed

### DIFF
--- a/src/contracts/CrossChainReceiver.sol
+++ b/src/contracts/CrossChainReceiver.sol
@@ -192,16 +192,17 @@ contract CrossChainReceiver is OwnableWithGuardian, ICrossChainReceiver {
         msg.sender,
         newConfirmations
       );
-
-      // checks that the message was not delivered before, so it will not try to deliver again when message arrives
+      // Checks that the message was not confirmed and/or delivered before, so it will not try to deliver again when message arrives
       // from additional bridges after reaching required number of confirmations
+      if (_envelopesState[envelopeId] != EnvelopeState.None) {
+        return;
+      }
+
       // >= is used for the case when confirmations gets lowered before message reached the old _requiredConfirmations
       // but on receiving new messages it surpasses the current _requiredConfirmations. So it doesn't get stuck (if using ==)
-      // Envelope can only be set as confirmed or delivered once
       if (
         configuration.requiredConfirmation > 0 &&
-        newConfirmations >= configuration.requiredConfirmation &&
-        _envelopesState[envelopeId] == EnvelopeState.None
+        newConfirmations >= configuration.requiredConfirmation
       ) {
         _envelopesState[envelopeId] = EnvelopeState.Delivered;
         try

--- a/src/contracts/CrossChainReceiver.sol
+++ b/src/contracts/CrossChainReceiver.sol
@@ -159,10 +159,21 @@ contract CrossChainReceiver is OwnableWithGuardian, ICrossChainReceiver {
       Errors.CHAIN_ID_MISMATCH
     );
     bytes32 envelopeId = transaction.getEnvelopeId();
-    // if envelope was confirmed before, just return
-    if (_envelopesState[envelopeId] != EnvelopeState.None) return;
 
     bytes32 transactionId = TransactionUtils.getId(encodedTransaction);
+
+    // if envelope was confirmed before, just return
+    if (_envelopesState[envelopeId] != EnvelopeState.None) {
+      emit TransactionReceivedWhenConfirmed(
+        transactionId,
+        envelopeId,
+        originChainId,
+        transaction,
+        msg.sender
+      );
+      return;
+    }
+
     TransactionState storage internalTransaction = _transactionsState[transactionId];
     ReceiverConfiguration memory configuration = _configurationsByChain[originChainId]
       .configuration;

--- a/src/contracts/interfaces/ICrossChainReceiver.sol
+++ b/src/contracts/interfaces/ICrossChainReceiver.sol
@@ -93,6 +93,22 @@ interface ICrossChainReceiver {
   }
 
   /**
+   * @notice emitted when a transaction has been received after a message has already been confirmed
+   * @param transactionId id of the transaction
+   * @param envelopeId id of the envelope
+   * @param originChainId id of the chain where the envelope originated
+   * @param transaction the Transaction type data
+   * @param bridgeAdapter address of the bridge adapter who received the message (deployed on current network)
+   */
+  event TransactionReceivedWhenConfirmed(
+    bytes32 transactionId,
+    bytes32 indexed envelopeId,
+    uint256 indexed originChainId,
+    Transaction transaction,
+    address indexed bridgeAdapter
+  );
+
+  /**
    * @notice emitted when a transaction has been received successfully
    * @param transactionId id of the transaction
    * @param envelopeId id of the envelope

--- a/src/contracts/interfaces/ICrossChainReceiver.sol
+++ b/src/contracts/interfaces/ICrossChainReceiver.sol
@@ -93,22 +93,6 @@ interface ICrossChainReceiver {
   }
 
   /**
-   * @notice emitted when a transaction has been received after a message has already been confirmed
-   * @param transactionId id of the transaction
-   * @param envelopeId id of the envelope
-   * @param originChainId id of the chain where the envelope originated
-   * @param transaction the Transaction type data
-   * @param bridgeAdapter address of the bridge adapter who received the message (deployed on current network)
-   */
-  event TransactionReceivedWhenConfirmed(
-    bytes32 transactionId,
-    bytes32 indexed envelopeId,
-    uint256 indexed originChainId,
-    Transaction transaction,
-    address indexed bridgeAdapter
-  );
-
-  /**
    * @notice emitted when a transaction has been received successfully
    * @param transactionId id of the transaction
    * @param envelopeId id of the envelope

--- a/tests/CrossChainReceiver.t.sol
+++ b/tests/CrossChainReceiver.t.sol
@@ -41,14 +41,6 @@ contract CrossChainReceiverTest is BaseTest {
     uint8 confirmations
   );
 
-  event TransactionReceivedWhenConfirmed(
-    bytes32 transactionId,
-    bytes32 indexed envelopeId,
-    uint256 indexed originChainId,
-    Transaction transaction,
-    address indexed bridgeAdapter
-  );
-
   event EnvelopeDeliveryAttempted(bytes32 envelopeId, Envelope envelope, bool isDelivered);
 
   event NewInvalidation(uint256 invalidTimestamp, uint256 indexed chainId);

--- a/tests/CrossChainReceiver.t.sol
+++ b/tests/CrossChainReceiver.t.sol
@@ -506,12 +506,13 @@ contract CrossChainReceiverTest is BaseTest {
     // receive 2nd cross chain message after its already confirmed
     hoax(BRIDGE_ADAPTER_2);
     vm.expectEmit(true, true, true, true);
-    emit TransactionReceivedWhenConfirmed(
+    emit TransactionReceived(
       txExtended.transactionId,
       txExtended.envelopeId,
       txExtended.envelope.originChainId,
       txExtended.transaction,
-      BRIDGE_ADAPTER_2
+      BRIDGE_ADAPTER_2,
+      2
     );
     crossChainReceiver.receiveCrossChainMessage(
       txExtended.transactionEncoded,
@@ -521,12 +522,12 @@ contract CrossChainReceiverTest is BaseTest {
     // check internal transaction
     assertEq(
       crossChainReceiver.isTransactionReceivedByAdapter(txExtended.transactionId, BRIDGE_ADAPTER_2),
-      false
+      true
     );
     internalTransactionState = crossChainReceiver.getTransactionState(txExtended.transactionId);
     internalEnvelopeState = crossChainReceiver.getEnvelopeState(txExtended.envelopeId);
 
-    assertEq(internalTransactionState.confirmations, 1);
+    assertEq(internalTransactionState.confirmations, 2);
     assertEq(internalTransactionState.firstBridgedAt, block.timestamp);
     assertTrue(internalEnvelopeState == ICrossChainReceiver.EnvelopeState.Delivered);
   }


### PR DESCRIPTION
moves conditional to return when message already confirmed / delivered to after internal state has been updated and received message event has been emitted.

This way all messages are treated equally independently of the state. 