### PR TITLE
feat: add methods to register first bridge adapters

### DIFF
--- a/src/contracts/CrossChainForwarder.sol
+++ b/src/contracts/CrossChainForwarder.sol
@@ -262,7 +262,7 @@ contract CrossChainForwarder is OwnableWithGuardian, ICrossChainForwarder {
   }
 
   /// @inheritdoc ICrossChainForwarder
-  function enableFirstBridgeAdapter(
+  function enableInitialBridgeAdapter(
     ForwarderBridgeAdapterConfigInput memory bridgeAdapter
   ) external onlyOwnerOrGuardian {
     ChainIdBridgeConfig[] memory destinationChainConfig = _bridgeAdaptersByChain[

--- a/src/contracts/CrossChainForwarder.sol
+++ b/src/contracts/CrossChainForwarder.sol
@@ -261,6 +261,24 @@ contract CrossChainForwarder is OwnableWithGuardian, ICrossChainForwarder {
     _disableBridgeAdapters(bridgeAdapters);
   }
 
+  /// @inheritdoc ICrossChainForwarder
+  function enableFirstBridgeAdapter(
+    ForwarderBridgeAdapterConfigInput memory bridgeAdapter
+  ) external onlyOwnerOrGuardian {
+    ChainIdBridgeConfig[] memory destinationChainConfig = _bridgeAdaptersByChain[
+      bridgeAdapter.destinationChainId
+    ];
+    require(
+      destinationChainConfig.length == 0,
+      Errors.ADAPTERS_ALREADY_ENABLED_FOR_DESTINATION_CHAIN
+    );
+    ForwarderBridgeAdapterConfigInput[]
+      memory bridgeAdapters = new ForwarderBridgeAdapterConfigInput[](1);
+    bridgeAdapters[0] = bridgeAdapter;
+
+    _enableBridgeAdapters(bridgeAdapters);
+  }
+
   /**
    * @notice internal method that has the logic to forward a transaction to the specified chain
    * @param envelopeId the id of the envelope

--- a/src/contracts/CrossChainReceiver.sol
+++ b/src/contracts/CrossChainReceiver.sol
@@ -144,7 +144,7 @@ contract CrossChainReceiver is OwnableWithGuardian, ICrossChainReceiver {
   // Also could make sense to allow the full ReceiverBridgeAdapterConfigInput object in case we want to set an adapter
   // for multiple new chains???
   /// @inheritdoc ICrossChainReceiver
-  function allowFirstReceiverBridgeAdapter(
+  function allowInitialReceiverBridgeAdapter(
     address bridgeAdapter,
     uint256 chainId
   ) external onlyOwnerOrGuardian {

--- a/src/contracts/CrossChainReceiver.sol
+++ b/src/contracts/CrossChainReceiver.sol
@@ -140,6 +140,31 @@ contract CrossChainReceiver is OwnableWithGuardian, ICrossChainReceiver {
     _updateReceiverBridgeAdapters(bridgeAdaptersInput, true);
   }
 
+  // TODO: not entirely sure if this method makes sense.
+  // Also could make sense to allow the full ReceiverBridgeAdapterConfigInput object in case we want to set an adapter
+  // for multiple new chains???
+  /// @inheritdoc ICrossChainReceiver
+  function allowFirstReceiverBridgeAdapter(
+    address bridgeAdapter,
+    uint256 chainId
+  ) external onlyOwnerOrGuardian {
+    require(
+      _configurationsByChain[chainId].allowedBridgeAdapters.values().length == 0,
+      Errors.CHAIN_MUST_NOT_HAVE_ANY_RECEIVER_ADAPTER_SET
+    );
+
+    uint256[] memory chainIds = new uint256[](1);
+    chainIds[0] = chainId;
+    ReceiverBridgeAdapterConfigInput[]
+      memory bridgeAdaptersInput = new ReceiverBridgeAdapterConfigInput[](1);
+    bridgeAdaptersInput[0] = ReceiverBridgeAdapterConfigInput({
+      bridgeAdapter: bridgeAdapter,
+      chainIds: chainIds
+    });
+
+    _updateReceiverBridgeAdapters(bridgeAdaptersInput, true);
+  }
+
   /// @inheritdoc ICrossChainReceiver
   function disallowReceiverBridgeAdapters(
     ReceiverBridgeAdapterConfigInput[] memory bridgeAdapters

--- a/src/contracts/interfaces/ICrossChainForwarder.sol
+++ b/src/contracts/interfaces/ICrossChainForwarder.sol
@@ -186,6 +186,15 @@ interface ICrossChainForwarder {
   function disableBridgeAdapters(BridgeAdapterToDisable[] memory bridgeAdapters) external;
 
   /**
+   * @notice method to enable a bridge adapter for a network where no adapter is set yet
+   * @param bridgeAdapter object with the new bridge adapter configuration
+   * @dev only callable by guardian and owner
+   */
+  function enableFirstBridgeAdapter(
+    ForwarderBridgeAdapterConfigInput memory bridgeAdapter
+  ) external;
+
+  /**
    * @notice method to remove sender addresses
    * @param senders list of addresses to remove
    */

--- a/src/contracts/interfaces/ICrossChainForwarder.sol
+++ b/src/contracts/interfaces/ICrossChainForwarder.sol
@@ -190,7 +190,7 @@ interface ICrossChainForwarder {
    * @param bridgeAdapter object with the new bridge adapter configuration
    * @dev only callable by guardian and owner
    */
-  function enableFirstBridgeAdapter(
+  function enableInitialBridgeAdapter(
     ForwarderBridgeAdapterConfigInput memory bridgeAdapter
   ) external;
 

--- a/src/contracts/interfaces/ICrossChainReceiver.sol
+++ b/src/contracts/interfaces/ICrossChainReceiver.sol
@@ -276,5 +276,5 @@ interface ICrossChainReceiver {
    * @param chainId id of the chain that the bridge adapter will receive messages from
    * @dev callable by guardian and owner
    */
-  function allowFirstReceiverBridgeAdapter(address bridgeAdapter, uint256 chainId) external;
+  function allowInitialReceiverBridgeAdapter(address bridgeAdapter, uint256 chainId) external;
 }

--- a/src/contracts/interfaces/ICrossChainReceiver.sol
+++ b/src/contracts/interfaces/ICrossChainReceiver.sol
@@ -269,4 +269,12 @@ interface ICrossChainReceiver {
   function disallowReceiverBridgeAdapters(
     ReceiverBridgeAdapterConfigInput[] memory bridgeAdaptersInput
   ) external;
+
+  /**
+   * @notice method to add a bridge adapter to the allowed list, for a chain with no current adapter set
+   * @param bridgeAdapter address of the bridge adapter to set
+   * @param chainId id of the chain that the bridge adapter will receive messages from
+   * @dev callable by guardian and owner
+   */
+  function allowFirstReceiverBridgeAdapter(address bridgeAdapter, uint256 chainId) external;
 }

--- a/src/contracts/libs/Errors.sol
+++ b/src/contracts/libs/Errors.sol
@@ -46,4 +46,6 @@ library Errors {
   string public constant CALLER_NOT_GNOSIS_ARBITRARY_MESSAGE_BRIDGE = '37'; // the caller must be the Gnosis AMB contract
   string public constant ZERO_GNOSIS_ARBITRARY_MESSAGE_BRIDGE = '38'; // The passed Gnosis AMB contract is zero
   string public constant CALLER_NOT_ZK_EVM_BRIDGE = '39'; // the caller must be the zk evm bridge
+  string public constant ADAPTERS_ALREADY_ENABLED_FOR_DESTINATION_CHAIN = '40'; // destination chain already has at least one adapter set, for communication
+  string public constant CHAIN_MUST_NOT_HAVE_ANY_RECEIVER_ADAPTER_SET = '41'; // there is already one adapter set, that can receive messages from origin chain
 }


### PR DESCRIPTION
Adds methods to register initial bridge adapters for networks that have no settings:

- FCC: enableInitialBridgeAdapter
- RCC: allowInitialReceiverBridgeAdapter

This will enable guardian to add adapters for new networks, without the need for a specific proposal (needed before the activation proposal)