### PR TITLE
feat: Add Linea network support

### DIFF
--- a/scripts/Adapters/DeployLineaAdapter.sol
+++ b/scripts/Adapters/DeployLineaAdapter.sol
@@ -48,7 +48,7 @@ abstract contract BaseDeployLineaAdapter is BaseAdapterScript {
       LineaAdapterDeploymentHelper.getAdapterCode(
         LineaAdapterDeploymentHelper.LineaAdapterArgs({
           baseArgs: baseArgs,
-          inbox: LINEA_MESSAGE_SERVICE()
+          lineaMessageService: LINEA_MESSAGE_SERVICE()
         })
       );
   }

--- a/scripts/Adapters/DeployLineaAdapter.sol
+++ b/scripts/Adapters/DeployLineaAdapter.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import './BaseAdapterScript.sol';
+import {LineaAdapter, ILineaAdapter} from '../../src/contracts/adapters/linea/LineaAdapter.sol';
+import {LineaAdapterTestnet} from '../contract_extensions/LineaAdapter.sol';
+
+library LineaAdapterDeploymentHelper {
+  struct LineaAdapterArgs {
+    BaseAdapterArgs baseArgs;
+    address lineaMessageService;
+  }
+
+  function getAdapterCode(LineaAdapterArgs memory lineaArgs) internal pure returns (bytes memory) {
+    bytes memory creationCode = lineaArgs.baseArgs.isTestnet
+      ? type(LineaAdapterTestnet).creationCode
+      : type(LineaAdapter).creationCode;
+
+    return
+      abi.encodePacked(
+        creationCode,
+        abi.encode(
+          lineaArgs.baseArgs.crossChainController,
+          lineaArgs.lineaMessageService,
+          lineaArgs.baseArgs.providerGasLimit,
+          lineaArgs.baseArgs.trustedRemotes
+        )
+      );
+  }
+}
+
+abstract contract BaseDeployLineaAdapter is BaseAdapterScript {
+  function LINEA_MESSAGE_SERVICE() internal view virtual returns (address) {
+    return address(0);
+  }
+
+  function PROVIDER_GAS_LIMIT() internal view virtual override returns (uint256) {
+    return 150_000;
+  }
+
+  function _getAdapterByteCode(
+    BaseAdapterArgs memory baseArgs
+  ) internal view override returns (bytes memory) {
+    require(baseArgs.trustedRemotes.length == 1, 'Linea adapter can only have one remote');
+    require(LINEA_MESSAGE_SERVICE() != address(0), 'Linea message service can not be 0');
+
+    return
+      LineaAdapterDeploymentHelper.getAdapterCode(
+        LineaAdapterDeploymentHelper.LineaAdapterArgs({
+          baseArgs: baseArgs,
+          inbox: LINEA_MESSAGE_SERVICE()
+        })
+      );
+  }
+}

--- a/scripts/Adapters/DeployLineaAdapter.sol
+++ b/scripts/Adapters/DeployLineaAdapter.sol
@@ -20,10 +20,12 @@ library LineaAdapterDeploymentHelper {
       abi.encodePacked(
         creationCode,
         abi.encode(
-          lineaArgs.baseArgs.crossChainController,
-          lineaArgs.lineaMessageService,
-          lineaArgs.baseArgs.providerGasLimit,
-          lineaArgs.baseArgs.trustedRemotes
+          ILineaAdapter.LineaParams({
+            crossChainController: lineaArgs.baseArgs.crossChainController,
+            lineaMessageService: lineaArgs.lineaMessageService,
+            providerGasLimit: lineaArgs.baseArgs.providerGasLimit,
+            trustedRemotes: lineaArgs.baseArgs.trustedRemotes
+          })
         )
       );
   }

--- a/scripts/contract_extensions/LineaAdapter.sol
+++ b/scripts/contract_extensions/LineaAdapter.sol
@@ -10,25 +10,9 @@ import {ILineaAdapter, LineaAdapter} from '../../src/contracts/adapters/linea/Li
  */
 contract LineaAdapterTestnet is LineaAdapter {
   /**
-   * @param crossChainController address of the cross chain controller that will use this bridge adapter
-   * @param lineaMessageService linea entry point address
-   * @param trustedRemotes list of remote configurations to set as trusted
+   * @param params object containing the necessary parameters to initialize the contract
    */
-  constructor(
-    address crossChainController,
-    address lineaMessageService,
-    uint256 providerGasLimit,
-    TrustedRemotesConfig[] memory trustedRemotes
-  )
-    LineaAdapter(
-      ILineaAdapter.LineaParams({
-        crossChainController: crossChainController,
-        lineaMessageService: lineaMessageService,
-        providerGasLimit: providerGasLimit,
-        trustedRemotes: trustedRemotes
-      })
-    )
-  {}
+  constructor(ILineaAdapter.LineaParams memory params) LineaAdapter(params) {}
 
   /// @inheritdoc ILineaAdapter
   function isDestinationChainIdSupported(uint256 chainId) public pure override returns (bool) {

--- a/scripts/contract_extensions/LineaAdapter.sol
+++ b/scripts/contract_extensions/LineaAdapter.sol
@@ -19,7 +19,16 @@ contract LineaAdapterTestnet is LineaAdapter {
     address lineaMessageService,
     uint256 providerGasLimit,
     TrustedRemotesConfig[] memory trustedRemotes
-  ) LineaAdapter(crossChainController, lineaMessageService, providerGasLimit, trustedRemotes) {}
+  )
+    LineaAdapter(
+      ILineaAdapter.LineaParams({
+        crossChainController: crossChainController,
+        lineaMessageService: lineaMessageService,
+        providerGasLimit: providerGasLimit,
+        trustedRemotes: trustedRemotes
+      })
+    )
+  {}
 
   /// @inheritdoc ILineaAdapter
   function isDestinationChainIdSupported(uint256 chainId) public pure override returns (bool) {

--- a/scripts/contract_extensions/LineaAdapter.sol
+++ b/scripts/contract_extensions/LineaAdapter.sol
@@ -19,15 +19,7 @@ contract LineaAdapterTestnet is LineaAdapter {
     address lineaMessageService,
     uint256 providerGasLimit,
     TrustedRemotesConfig[] memory trustedRemotes
-  )
-    LineaAdapter(
-      crossChainController,
-      lineaMessageService,
-      providerGasLimit,
-      trustedRemotes,
-      'Linea native  adapter'
-    )
-  {}
+  ) LineaAdapter(crossChainController, lineaMessageService, providerGasLimit, trustedRemotes) {}
 
   /// @inheritdoc ILineaAdapter
   function isDestinationChainIdSupported(uint256 chainId) public pure override returns (bool) {

--- a/scripts/contract_extensions/LineaAdapter.sol
+++ b/scripts/contract_extensions/LineaAdapter.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.8;
+
+import {TestNetChainIds} from 'solidity-utils/contracts/utils/ChainHelpers.sol';
+import {ILineaAdapter, LineaAdapter} from '../../src/contracts/adapters/linea/LineaAdapter.sol';
+
+/**
+ * @title LineaAdapterTestnet
+ * @author BGD Labs
+ */
+contract LineaAdapterTestnet is LineaAdapter {
+  /**
+   * @param crossChainController address of the cross chain controller that will use this bridge adapter
+   * @param lineaMessageService linea entry point address
+   * @param trustedRemotes list of remote configurations to set as trusted
+   */
+  constructor(
+    address crossChainController,
+    address lineaMessageService,
+    uint256 providerGasLimit,
+    TrustedRemotesConfig[] memory trustedRemotes
+  )
+    LineaAdapter(
+      crossChainController,
+      lineaMessageService,
+      providerGasLimit,
+      trustedRemotes,
+      'Linea native  adapter'
+    )
+  {}
+
+  /// @inheritdoc ILineaAdapter
+  function isDestinationChainIdSupported(uint256 chainId) public pure override returns (bool) {
+    return chainId == TestNetChainIds.LINEA_SEPOLIA;
+  }
+
+  /// @inheritdoc ILineaAdapter
+  function getOriginChainId() public pure override returns (uint256) {
+    return TestNetChainIds.ETHEREUM_SEPOLIA;
+  }
+}

--- a/src/contracts/adapters/linea/ILineaAdapter.sol
+++ b/src/contracts/adapters/linea/ILineaAdapter.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/**
+ * @title ILineaAdapter
+ * @author BGD Labs
+ * @notice interface containing the events, objects and method definitions used in the Linea bridge adapter
+ */
+interface ILineaAdapter {
+  /**
+   * @notice method to get the Linea message service address
+   * @return address of the Linea message service
+   */
+  function LINEA_MESSAGE_SERVICE() external view returns (address);
+
+  /**
+   * @notice method to know if a destination chain is supported by adapter
+   * @return flag indicating if the destination chain is supported by the adapter
+   */
+  function isDestinationChainIdSupported(uint256 chainId) external view returns (bool);
+
+  /**
+   * @notice method called by Linea message service with the bridged message
+   * @param message bytes containing the bridged information
+   */
+  function receiveMessage(bytes memory message) external;
+
+  /**
+   * @notice method to get the origin chain id
+   * @return id of the chain where the messages originate.
+   * @dev this method is needed as Optimism does not pass the origin chain
+   */
+  function getOriginChainId() external view returns (uint256);
+}

--- a/src/contracts/adapters/linea/ILineaAdapter.sol
+++ b/src/contracts/adapters/linea/ILineaAdapter.sol
@@ -1,12 +1,28 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+import {IBaseAdapter} from '../IBaseAdapter.sol';
+
 /**
  * @title ILineaAdapter
  * @author BGD Labs
  * @notice interface containing the events, objects and method definitions used in the Linea bridge adapter
  */
-interface ILineaAdapter {
+interface ILineaAdapter is IBaseAdapter {
+  /**
+   * @notice struct used to pass parameters to the Linea constructor
+   * @param crossChainController address of the cross chain controller that will use this bridge adapter
+   * @param lineaMessageService Linea entry point address
+   * @param providerGasLimit base gas limit used by the bridge adapter
+   * @param trustedRemotes list of remote configurations to set as trusted
+   */
+  struct LineaParams {
+    address crossChainController;
+    address lineaMessageService;
+    uint256 providerGasLimit;
+    TrustedRemotesConfig[] trustedRemotes;
+  }
+
   /**
    * @notice method to get the Linea message service address
    * @return address of the Linea message service

--- a/src/contracts/adapters/linea/LineaAdapter.sol
+++ b/src/contracts/adapters/linea/LineaAdapter.sol
@@ -67,11 +67,11 @@ contract LineaAdapter is ILineaAdapter, BaseAdapter {
 
     require(address(this).balance >= L2_FEE, Errors.NOT_ENOUGH_VALUE_TO_PAY_BRIDGE_FEES);
 
-    // @dev we set _fee to 0 because for now we will do the claim manually. Until an automated way of getting the
-    // price is implemented by Linea
+    // @dev we set _fee to hardcoded L2_FEE to overpay to ensure automatic claiming. If by some case it is not enough then
+    // we will do the claim manually. Until an automated way of getting the price is implemented by Linea
     IMessageService(LINEA_MESSAGE_SERVICE).sendMessage{value: L2_FEE}(
       receiver,
-      0,
+      L2_FEE,
       abi.encodeWithSelector(ILineaAdapter.receiveMessage.selector, message)
     );
     return (LINEA_MESSAGE_SERVICE, 0);

--- a/src/contracts/adapters/linea/LineaAdapter.sol
+++ b/src/contracts/adapters/linea/LineaAdapter.sol
@@ -21,6 +21,8 @@ contract LineaAdapter is ILineaAdapter, BaseAdapter {
   /// @inheritdoc ILineaAdapter
   address public immutable LINEA_MESSAGE_SERVICE;
 
+  uint256 public constant L2_FEE = 0.003 ether;
+
   /**
    * @notice only calls from the set message service are accepted.
    */
@@ -62,9 +64,12 @@ contract LineaAdapter is ILineaAdapter, BaseAdapter {
     );
     require(receiver != address(0), Errors.RECEIVER_NOT_SET);
 
+
+    require(address(this).balance >= L2_FEE, Errors.NOT_ENOUGH_VALUE_TO_PAY_BRIDGE_FEES);
+
     // @dev we set _fee to 0 because for now we will do the claim manually. Until an automated way of getting the
     // price is implemented by Linea
-    IMessageService(LINEA_MESSAGE_SERVICE).sendMessage(
+    IMessageService(LINEA_MESSAGE_SERVICE).sendMessage{value: L2_FEE}(
       receiver,
       0,
       abi.encodeWithSelector(ILineaAdapter.receiveMessage.selector, message)
@@ -90,7 +95,7 @@ contract LineaAdapter is ILineaAdapter, BaseAdapter {
   }
 
   /// @inheritdoc ILineaAdapter
-  function isDestinationChainIdSupported(uint256 chainId) public view virtual returns (bool) {
+  function isDestinationChainIdSupported(uint256 chainId) public pure virtual returns (bool) {
     return chainId == ChainIds.LINEA;
   }
 

--- a/src/contracts/adapters/linea/LineaAdapter.sol
+++ b/src/contracts/adapters/linea/LineaAdapter.sol
@@ -32,23 +32,22 @@ contract LineaAdapter is ILineaAdapter, BaseAdapter {
    * @param crossChainController address of the cross chain controller that will use this bridge adapter
    * @param lineaMessageService Linea entry point address
    * @param providerGasLimit base gas limit used by the bridge adapter
-   * @param adapterName string indicating the adapter name
    * @param trustedRemotes list of remote configurations to set as trusted
    */
   constructor(
     address crossChainController,
     address lineaMessageService,
     uint256 providerGasLimit,
-    string memory adapterName,
     TrustedRemotesConfig[] memory trustedRemotes
-  ) BaseAdapter(crossChainController, providerGasLimit, adapterName, trustedRemotes) {
+  ) BaseAdapter(crossChainController, providerGasLimit, 'Linea native adapter', trustedRemotes) {
+    require(lineaMessageService != address(0), Errors.LINEA_MESSAGE_SERVICE_CANT_BE_ADDRESS_0);
     LINEA_MESSAGE_SERVICE = lineaMessageService;
   }
 
   /// @inheritdoc IBaseAdapter
   function forwardMessage(
     address receiver,
-    uint256 executionGasLimit,
+    uint256,
     uint256 destinationChainId,
     bytes calldata message
   ) external virtual returns (address, uint256) {
@@ -69,7 +68,7 @@ contract LineaAdapter is ILineaAdapter, BaseAdapter {
   }
 
   /// @inheritdoc ILineaAdapter
-  function ovmReceive(bytes calldata message) external onlyLineaMessageService {
+  function receiveMessage(bytes calldata message) external onlyLineaMessageService {
     uint256 originChainId = getOriginChainId();
     address srcAddress = IMessageService(LINEA_MESSAGE_SERVICE).sender();
     require(

--- a/src/contracts/adapters/linea/LineaAdapter.sol
+++ b/src/contracts/adapters/linea/LineaAdapter.sol
@@ -58,12 +58,11 @@ contract LineaAdapter is ILineaAdapter, BaseAdapter {
     );
     require(receiver != address(0), Errors.RECEIVER_NOT_SET);
 
-    uint256 cost = 0; // TODO: find how to calculate cost
-    require(cost <= address(this).balance, Errors.NOT_ENOUGH_VALUE_TO_PAY_BRIDGE_FEES);
-
-    IMessageService(LINEA_MESSAGE_SERVICE).sendMessage{value: cost}(
+    // @dev we set _fee to 0 because for now we will do the claim manually. Until an automated way of getting the
+    // price is implemented by Linea
+    IMessageService(LINEA_MESSAGE_SERVICE).sendMessage(
       receiver,
-      _fee,
+      0,
       abi.encodeWithSelector(ILineaAdapter.receiveMessage.selector, message)
     );
     return (LINEA_MESSAGE_SERVICE, 0);

--- a/src/contracts/adapters/linea/LineaAdapter.sol
+++ b/src/contracts/adapters/linea/LineaAdapter.sol
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import {IMessageService} from './interfaces/IMessageService.sol';
+import {BaseAdapter, IBaseAdapter} from '../BaseAdapter.sol';
+import {ChainIds} from 'solidity-utils/contracts/utils/ChainHelpers.sol';
+import {Errors} from '../../libs/Errors.sol';
+import {ILineaAdapter} from './ILineaAdapter.sol';
+import {SafeCast} from 'solidity-utils/contracts/oz-common/SafeCast.sol';
+
+/**
+ * @title LineaAdapter
+ * @author BGD Labs
+ * @notice Optimism bridge adapter. Used to send and receive messages cross chain between Ethereum and Optimism
+ * @dev it uses the eth balance of CrossChainController contract to pay for message bridging as the method to bridge
+        is called via delegate call
+ * @dev note that this adapter is can only be used for the communication path ETHEREUM -> LINEA
+ */
+contract LineaAdapter is ILineaAdapter, BaseAdapter {
+  /// @inheritdoc ILineaAdapter
+  address public immutable LINEA_MESSAGE_SERVICE;
+
+  /**
+   * @notice only calls from the set ovm are accepted.
+   */
+  modifier onlyLineaMessageService() {
+    require(msg.sender == address(LINEA_MESSAGE_SERVICE), Errors.CALLER_NOT_LINEA_MESSAGE_SERVICE);
+    _;
+  }
+
+  /**
+   * @param crossChainController address of the cross chain controller that will use this bridge adapter
+   * @param lineaMessageService Linea entry point address
+   * @param providerGasLimit base gas limit used by the bridge adapter
+   * @param adapterName string indicating the adapter name
+   * @param trustedRemotes list of remote configurations to set as trusted
+   */
+  constructor(
+    address crossChainController,
+    address lineaMessageService,
+    uint256 providerGasLimit,
+    string memory adapterName,
+    TrustedRemotesConfig[] memory trustedRemotes
+  ) BaseAdapter(crossChainController, providerGasLimit, adapterName, trustedRemotes) {
+    LINEA_MESSAGE_SERVICE = lineaMessageService;
+  }
+
+  /// @inheritdoc IBaseAdapter
+  function forwardMessage(
+    address receiver,
+    uint256 executionGasLimit,
+    uint256 destinationChainId,
+    bytes calldata message
+  ) external virtual returns (address, uint256) {
+    require(
+      isDestinationChainIdSupported(destinationChainId),
+      Errors.DESTINATION_CHAIN_ID_NOT_SUPPORTED
+    );
+    require(receiver != address(0), Errors.RECEIVER_NOT_SET);
+
+    uint256 cost = 0; // TODO: find how to calculate cost
+    require(cost <= address(this).balance, Errors.NOT_ENOUGH_VALUE_TO_PAY_BRIDGE_FEES);
+
+    IMessageService(LINEA_MESSAGE_SERVICE).sendMessage{value: cost}(
+      receiver,
+      _fee,
+      abi.encodeWithSelector(ILineaAdapter.receiveMessage.selector, message)
+    );
+    return (LINEA_MESSAGE_SERVICE, 0);
+  }
+
+  /// @inheritdoc ILineaAdapter
+  function ovmReceive(bytes calldata message) external onlyLineaMessageService {
+    uint256 originChainId = getOriginChainId();
+    address srcAddress = IMessageService(LINEA_MESSAGE_SERVICE).sender();
+    require(
+      _trustedRemotes[originChainId] == srcAddress && srcAddress != address(0),
+      Errors.REMOTE_NOT_TRUSTED
+    );
+
+    _registerReceivedMessage(message, originChainId);
+  }
+
+  /// @inheritdoc ILineaAdapter
+  function getOriginChainId() public pure virtual returns (uint256) {
+    return ChainIds.ETHEREUM;
+  }
+
+  /// @inheritdoc ILineaAdapter
+  function isDestinationChainIdSupported(uint256 chainId) public view virtual returns (bool) {
+    return chainId == ChainIds.LINEA;
+  }
+
+  /// @inheritdoc IBaseAdapter
+  function nativeToInfraChainId(uint256 nativeChainId) public pure override returns (uint256) {
+    return nativeChainId;
+  }
+
+  /// @inheritdoc IBaseAdapter
+  function infraToNativeChainId(uint256 infraChainId) public pure override returns (uint256) {
+    return infraChainId;
+  }
+}

--- a/src/contracts/adapters/linea/LineaAdapter.sol
+++ b/src/contracts/adapters/linea/LineaAdapter.sol
@@ -21,7 +21,7 @@ contract LineaAdapter is ILineaAdapter, BaseAdapter {
   /// @inheritdoc ILineaAdapter
   address public immutable LINEA_MESSAGE_SERVICE;
 
-  uint256 public constant L2_FEE = 0.003 ether;
+  uint256 public constant L2_FEE = 0.002 ether;
 
   /**
    * @notice only calls from the set message service are accepted.

--- a/src/contracts/adapters/linea/README.md
+++ b/src/contracts/adapters/linea/README.md
@@ -19,7 +19,7 @@ event MessageSent(
   );
 ```
 3. Go to the Linea block explorer: https://lineascan.build/ and add the Linea MessageService contract:
-- mainnet: [0x508Ca82Df566dCD1B0DE8296e70a96332cD644ec](https://sepolia.lineascan.build/address/0x508Ca82Df566dCD1B0DE8296e70a96332cD644ec#writeProxyContract)
+- mainnet: [0x508Ca82Df566dCD1B0DE8296e70a96332cD644ec](https://lineascan.build/address/0x508Ca82Df566dCD1B0DE8296e70a96332cD644ec#writeProxyContract)
 - sepolia: [0x971e727e956690b9957be6d51Ec16E73AcAC83A7](https://sepolia.lineascan.build/address/0x971e727e956690b9957be6d51Ec16E73AcAC83A7#writeProxyContract)
 Once there go to write as proxy contract, and fill the information from step 2 to the method `claimMessage` and execute the tx.
 Take into account that the topics, calldata and nonce must be in Hex format.

--- a/src/contracts/adapters/linea/README.md
+++ b/src/contracts/adapters/linea/README.md
@@ -1,0 +1,26 @@
+# Manual Message Claiming
+
+To manually claim a message sent from origin (Ethereum) on the Linea network follow these steps:
+
+1. Get the tx hash where the message was sent on the origin network (Ethereum). This is to get all the information
+needed on the following steps. Once you have the tx hash, go to the block explorer, input the tx hash, and then go to events.
+Once you are on the events page of the tx, locate the event `MessageSent`
+2. Go to the online event decode page: https://tools.deth.net/event-decoder and input the event topics from step 1, and the data.
+Add this code (event abi) to the ABI text box:
+```
+event MessageSent(
+    address indexed _from,
+    address indexed _to,
+    uint256 _fee,
+    uint256 _value,
+    uint256 _nonce,
+    bytes _calldata,
+    bytes32 indexed _messageHash
+  );
+```
+3. Go to the Linea block explorer: https://lineascan.build/ and add the Linea MessageService contract:
+- mainnet: [0x508Ca82Df566dCD1B0DE8296e70a96332cD644ec](https://sepolia.lineascan.build/address/0x508Ca82Df566dCD1B0DE8296e70a96332cD644ec#writeProxyContract)
+- sepolia: [0x971e727e956690b9957be6d51Ec16E73AcAC83A7](https://sepolia.lineascan.build/address/0x971e727e956690b9957be6d51Ec16E73AcAC83A7#writeProxyContract)
+Once there go to write as proxy contract, and fill the information from step 2 to the method `claimMessage` and execute the tx.
+Take into account that the topics, calldata and nonce must be in Hex format.
+

--- a/src/contracts/adapters/linea/interfaces/IMessageService.sol
+++ b/src/contracts/adapters/linea/interfaces/IMessageService.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+// Modified from: https://docs.linea.build/get-started/concepts/message-service#interface-imessageservicesol
+pragma solidity ^0.8.0;
+
+interface IMessageService {
+  /**
+   * @notice Sends a message for transporting from the given chain.
+   * @dev This function should be called with a msg.value = _value + _fee. The fee will be paid on the destination chain.
+   * @param _to The destination address on the destination chain.
+   * @param _fee The message service fee on the origin chain.
+   * @param _calldata The calldata used by the destination message service to call the destination contract.
+   */
+  function sendMessage(address _to, uint256 _fee, bytes calldata _calldata) external payable;
+
+  /**
+   * @notice Returns the original sender of the message on the origin layer.
+   * @return The original sender of the message on the origin layer.
+   */
+  function sender() external view returns (address);
+}

--- a/src/contracts/libs/Errors.sol
+++ b/src/contracts/libs/Errors.sol
@@ -52,4 +52,5 @@ library Errors {
   string public constant ZK_SYNC_BRIDGE_HUB_CANT_BE_ADDRESS_0 = '43'; // ZkSync Bridgehub can not be address 0
   string public constant CL_GAS_PRICE_ORACLE_CANT_BE_ADDRESS_0 = '44'; // ChainLink gas price oracle can not be address 0
   string public constant CALLER_NOT_LINEA_MESSAGE_SERVICE = '45'; // caller must be the Linea message service
+  string public constant LINEA_MESSAGE_SERVICE_CANT_BE_ADDRESS_0 = '46'; // Linea message service can not be address 0
 }

--- a/src/contracts/libs/Errors.sol
+++ b/src/contracts/libs/Errors.sol
@@ -51,4 +51,5 @@ library Errors {
   string public constant CALLER_NOT_WORMHOLE_RELAYER = '42'; // caller must be the Wormhole relayer
   string public constant ZK_SYNC_BRIDGE_HUB_CANT_BE_ADDRESS_0 = '43'; // ZkSync Bridgehub can not be address 0
   string public constant CL_GAS_PRICE_ORACLE_CANT_BE_ADDRESS_0 = '44'; // ChainLink gas price oracle can not be address 0
+  string public constant CALLER_NOT_LINEA_MESSAGE_SERVICE = '45'; // caller must be the Linea message service
 }

--- a/tests/adapters/LineaAdapter.t.sol
+++ b/tests/adapters/LineaAdapter.t.sol
@@ -34,10 +34,12 @@ contract LineaAdapterTest is BaseAdapterTest {
     originConfigs[0] = originConfig;
 
     lineaAdapter = new LineaAdapter(
-      crossChainController,
-      lineaMessageService,
-      baseGasLimit,
-      originConfigs
+      ILineaAdapter.LineaParams({
+        crossChainController: crossChainController,
+        lineaMessageService: lineaMessageService,
+        providerGasLimit: baseGasLimit,
+        trustedRemotes: originConfigs
+      })
     );
     _;
   }
@@ -69,7 +71,14 @@ contract LineaAdapterTest is BaseAdapterTest {
       memory originConfigs = new IBaseAdapter.TrustedRemotesConfig[](1);
     originConfigs[0] = originConfig;
     vm.expectRevert(bytes(Errors.LINEA_MESSAGE_SERVICE_CANT_BE_ADDRESS_0));
-    new LineaAdapter(crossChainController, address(0), baseGasLimit, originConfigs);
+    new LineaAdapter(
+      ILineaAdapter.LineaParams({
+        crossChainController: crossChainController,
+        lineaMessageService: address(0),
+        providerGasLimit: baseGasLimit,
+        trustedRemotes: originConfigs
+      })
+    );
   }
 
   function testInitialize(

--- a/tests/adapters/LineaAdapter.t.sol
+++ b/tests/adapters/LineaAdapter.t.sol
@@ -1,0 +1,275 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import {LineaAdapter, IBaseAdapter, ILineaAdapter, IMessageService} from '../../src/contracts/adapters/linea/LineaAdapter.sol';
+import {ICrossChainReceiver} from '../../src/contracts/interfaces/ICrossChainReceiver.sol';
+import {ChainIds} from 'solidity-utils/contracts/utils/ChainHelpers.sol';
+import {Errors} from '../../src/contracts/libs/Errors.sol';
+import {BaseAdapterTest} from './BaseAdapterTest.sol';
+
+contract LineaAdapterTest is BaseAdapterTest {
+  LineaAdapter internal lineaAdapter;
+  event SetTrustedRemote(uint256 indexed originChainId, address indexed originForwarder);
+
+  modifier setLineaAdapter(
+    address crossChainController,
+    address lineaMessageService,
+    address originForwarder,
+    uint256 baseGasLimit,
+    uint256 originChainId
+  ) {
+    vm.assume(crossChainController != tx.origin); // zkVM doesn't support mocking tx.origin
+    vm.assume(baseGasLimit < 1 ether);
+    _assumeSafeAddress(crossChainController);
+    _assumeSafeAddress(lineaMessageService);
+    vm.assume(originForwarder != address(0));
+    vm.assume(originChainId > 0);
+
+    IBaseAdapter.TrustedRemotesConfig memory originConfig = IBaseAdapter.TrustedRemotesConfig({
+      originForwarder: originForwarder,
+      originChainId: originChainId
+    });
+    IBaseAdapter.TrustedRemotesConfig[]
+      memory originConfigs = new IBaseAdapter.TrustedRemotesConfig[](1);
+    originConfigs[0] = originConfig;
+
+    lineaAdapter = new LineaAdapter(
+      crossChainController,
+      lineaMessageService,
+      baseGasLimit,
+      originConfigs
+    );
+    _;
+  }
+
+  struct Params {
+    address lineaMessageService;
+    address receiver;
+    uint256 dstGasLimit;
+    address caller;
+  }
+
+  function setUp() public {}
+
+  function testWrongLineaMessageSender(
+    address crossChainController,
+    uint256 baseGasLimit,
+    address originForwarder,
+    uint256 originChainId
+  ) public {
+    vm.assume(crossChainController != address(0));
+    vm.assume(originForwarder != address(0));
+    vm.assume(originChainId > 0);
+
+    IBaseAdapter.TrustedRemotesConfig memory originConfig = IBaseAdapter.TrustedRemotesConfig({
+      originForwarder: originForwarder,
+      originChainId: originChainId
+    });
+    IBaseAdapter.TrustedRemotesConfig[]
+      memory originConfigs = new IBaseAdapter.TrustedRemotesConfig[](1);
+    originConfigs[0] = originConfig;
+    vm.expectRevert(bytes(Errors.LINEA_MESSAGE_SERVICE_CANT_BE_ADDRESS_0));
+    new LineaAdapter(crossChainController, address(0), baseGasLimit, originConfigs);
+  }
+
+  function testInitialize(
+    address crossChainController,
+    address lineaMessageService,
+    address originForwarder,
+    uint256 baseGasLimit,
+    uint256 originChainId
+  )
+    public
+    setLineaAdapter(
+      crossChainController,
+      lineaMessageService,
+      originForwarder,
+      baseGasLimit,
+      originChainId
+    )
+  {
+    assertEq(lineaAdapter.getTrustedRemoteByChainId(originChainId), originForwarder);
+  }
+
+  function testForwardMessage(
+    address crossChainController,
+    address lineaMessageService,
+    address originForwarder,
+    uint256 baseGasLimit,
+    uint256 originChainId
+  )
+    public
+    setLineaAdapter(
+      crossChainController,
+      lineaMessageService,
+      originForwarder,
+      baseGasLimit,
+      originChainId
+    )
+  {
+    _testForwardMessage(
+      Params({
+        lineaMessageService: lineaMessageService,
+        receiver: address(135961),
+        dstGasLimit: 12,
+        caller: address(12354)
+      })
+    );
+  }
+
+  function testForwardMessageWhenChainNotSupported(
+    address crossChainController,
+    address lineaMessageService,
+    address originForwarder,
+    uint256 baseGasLimit,
+    uint256 originChainId,
+    uint256 dstGasLimit,
+    address receiver,
+    bytes memory message
+  )
+    public
+    setLineaAdapter(
+      crossChainController,
+      lineaMessageService,
+      originForwarder,
+      baseGasLimit,
+      originChainId
+    )
+  {
+    vm.assume(receiver != address(0));
+
+    vm.expectRevert(bytes(Errors.DESTINATION_CHAIN_ID_NOT_SUPPORTED));
+    lineaAdapter.forwardMessage(receiver, dstGasLimit, 11, message);
+  }
+
+  function testForwardMessageWhenWrongReceiver(
+    address crossChainController,
+    address lineaMessageService,
+    address originForwarder,
+    uint256 baseGasLimit,
+    uint256 originChainId,
+    uint256 dstGasLimit,
+    bytes memory message
+  )
+    public
+    setLineaAdapter(
+      crossChainController,
+      lineaMessageService,
+      originForwarder,
+      baseGasLimit,
+      originChainId
+    )
+  {
+    vm.expectRevert(bytes(Errors.RECEIVER_NOT_SET));
+    lineaAdapter.forwardMessage(address(0), dstGasLimit, ChainIds.LINEA, message);
+  }
+
+  function testReceive(
+    address crossChainController,
+    address lineaMessageService,
+    address originForwarder,
+    uint256 baseGasLimit,
+    bytes memory message
+  )
+    public
+    setLineaAdapter(crossChainController, lineaMessageService, originForwarder, baseGasLimit, 1)
+  {
+    hoax(lineaMessageService);
+
+    vm.mockCall(
+      lineaMessageService,
+      abi.encodeWithSelector(IMessageService.sender.selector),
+      abi.encode(originForwarder)
+    );
+    vm.mockCall(
+      crossChainController,
+      abi.encodeWithSelector(ICrossChainReceiver.receiveCrossChainMessage.selector),
+      abi.encode()
+    );
+    vm.expectCall(
+      crossChainController,
+      0,
+      abi.encodeWithSelector(ICrossChainReceiver.receiveCrossChainMessage.selector, message, 1)
+    );
+    lineaAdapter.receiveMessage(message);
+  }
+
+  function testReceiveWhenRemoteNotTrusted(
+    address crossChainController,
+    address lineaMessageService,
+    address originForwarder,
+    uint256 baseGasLimit,
+    bytes memory message,
+    address remote
+  )
+    public
+    setLineaAdapter(crossChainController, lineaMessageService, originForwarder, baseGasLimit, 1)
+  {
+    vm.assume(remote != originForwarder);
+    hoax(lineaMessageService);
+
+    vm.mockCall(
+      lineaMessageService,
+      abi.encodeWithSelector(IMessageService.sender.selector),
+      abi.encode(remote)
+    );
+    vm.expectRevert(bytes(Errors.REMOTE_NOT_TRUSTED));
+
+    lineaAdapter.receiveMessage(message);
+  }
+
+  function testReceiveWhenIncorrectOriginChainId(
+    address crossChainController,
+    address lineaMessageService,
+    address originForwarder,
+    uint256 baseGasLimit,
+    bytes memory message,
+    uint256 originChainId
+  )
+    public
+    setLineaAdapter(
+      crossChainController,
+      lineaMessageService,
+      originForwarder,
+      baseGasLimit,
+      originChainId
+    )
+  {
+    vm.assume(originChainId != 1);
+    hoax(lineaMessageService);
+
+    vm.mockCall(
+      lineaMessageService,
+      abi.encodeWithSelector(IMessageService.sender.selector),
+      abi.encode(originForwarder)
+    );
+    vm.expectRevert(bytes(Errors.REMOTE_NOT_TRUSTED));
+
+    lineaAdapter.receiveMessage(message);
+  }
+
+  function _testForwardMessage(Params memory params) internal {
+    bytes memory message = abi.encode('test message');
+
+    hoax(params.caller, 10 ether);
+
+    vm.mockCall(
+      params.lineaMessageService,
+      abi.encodeWithSelector(IMessageService.sendMessage.selector),
+      abi.encode()
+    );
+    (bool success, bytes memory returnData) = address(lineaAdapter).delegatecall(
+      abi.encodeWithSelector(
+        IBaseAdapter.forwardMessage.selector,
+        params.receiver,
+        params.dstGasLimit,
+        ChainIds.LINEA,
+        message
+      )
+    );
+    vm.clearMockedCalls();
+
+    assertEq(success, true);
+    assertEq(returnData, abi.encode(params.lineaMessageService, 0));
+  }
+}

--- a/tests/adapters/LineaAdapter.t.sol
+++ b/tests/adapters/LineaAdapter.t.sol
@@ -173,6 +173,30 @@ contract LineaAdapterTest is BaseAdapterTest {
     lineaAdapter.forwardMessage(address(0), dstGasLimit, ChainIds.LINEA, message);
   }
 
+  function testForwardMessageWhenNoValue(
+    address crossChainController,
+    address lineaMessageService,
+    address originForwarder,
+    uint256 baseGasLimit,
+    uint256 originChainId,
+    uint256 dstGasLimit,
+    address receiver,
+    bytes memory message
+  )
+    public
+    setLineaAdapter(
+      crossChainController,
+      lineaMessageService,
+      originForwarder,
+      baseGasLimit,
+      originChainId
+    )
+  {
+    vm.assume(receiver != address(0));
+    vm.expectRevert(bytes(Errors.NOT_ENOUGH_VALUE_TO_PAY_BRIDGE_FEES));
+    lineaAdapter.forwardMessage(receiver, dstGasLimit, ChainIds.LINEA, message);
+  }
+
   function testReceive(
     address crossChainController,
     address lineaMessageService,


### PR DESCRIPTION
Pr to add Linea native bridge to a.DI

- As first instance of the deployment, the Linea Adapter will not send fees to Linea network, meaning that the message will need to be claimed manually on destination network. This is done this way because Linea does not have any way to get the gas price on-chain on origin network (Ethereum)


Linea docs can be found here: https://docs.linea.build/get-started/concepts/message-service#technical-reference