### PR TITLE
feat: Add Mantle bridge adapter

### DIFF
--- a/scripts/Adapters/DeployMantleAdapter.sol
+++ b/scripts/Adapters/DeployMantleAdapter.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import {MantleAdapter} from '../../src/contracts/adapters/mantle/MantleAdapter.sol';
+import './BaseAdapterScript.sol';
+import {MantleAdapterTestnet} from '../contract_extensions/MantleAdapter.sol';
+
+library MantleAdapterDeploymentHelper {
+  struct MantleAdapterArgs {
+    BaseAdapterArgs baseArgs;
+    address ovm;
+  }
+
+  function getAdapterCode(MantleAdapterArgs memory mantleArgs) internal pure returns (bytes memory) {
+    bytes memory creationCode = mantleArgs.baseArgs.isTestnet
+      ? type(MantleAdapterTestnet).creationCode
+      : type(MantleAdapter).creationCode;
+
+    return
+      abi.encodePacked(
+        creationCode,
+        abi.encode(
+          mantleArgs.baseArgs.crossChainController,
+          mantleArgs.ovm,
+          mantleArgs.baseArgs.providerGasLimit,
+          mantleArgs.baseArgs.trustedRemotes
+        )
+      );
+  }
+}
+
+abstract contract BaseMantleAdapter is BaseAdapterScript {
+  function OVM() internal view virtual returns (address);
+
+  function _getAdapterByteCode(
+    BaseAdapterArgs memory baseArgs
+  ) internal view override returns (bytes memory) {
+    require(OVM() != address(0), 'Invalid OVM address');
+    require(baseArgs.trustedRemotes.length == 1, 'Adapter can only have one remote');
+
+    return
+      MantleAdapterDeploymentHelper.getAdapterCode(
+        MantleAdapterDeploymentHelper.MantleAdapterArgs({baseArgs: baseArgs, ovm: OVM()})
+      );
+  }
+}

--- a/scripts/Adapters/DeployMantleAdapter.sol
+++ b/scripts/Adapters/DeployMantleAdapter.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.0;
 
-import {MantleAdapter} from '../../src/contracts/adapters/mantle/MantleAdapter.sol';
+import {MantleAdapter, IMantleAdapter} from '../../src/contracts/adapters/mantle/MantleAdapter.sol';
 import './BaseAdapterScript.sol';
 import {MantleAdapterTestnet} from '../contract_extensions/MantleAdapter.sol';
 
@@ -20,10 +20,12 @@ library MantleAdapterDeploymentHelper {
       abi.encodePacked(
         creationCode,
         abi.encode(
-          mantleArgs.baseArgs.crossChainController,
-          mantleArgs.ovm,
-          mantleArgs.baseArgs.providerGasLimit,
-          mantleArgs.baseArgs.trustedRemotes
+          IMantleAdapter.MantleParams({
+            crossChainController: mantleArgs.baseArgs.crossChainController,
+            ovmCrossDomainMessenger: mantleArgs.ovm,
+            providerGasLimit: mantleArgs.baseArgs.providerGasLimit,
+            trustedRemotes: mantleArgs.baseArgs.trustedRemotes
+          })
         )
       );
   }

--- a/scripts/Adapters/DeployMantleAdapter.sol
+++ b/scripts/Adapters/DeployMantleAdapter.sol
@@ -36,7 +36,6 @@ abstract contract BaseMantleAdapter is BaseAdapterScript {
     BaseAdapterArgs memory baseArgs
   ) internal view override returns (bytes memory) {
     require(OVM() != address(0), 'Invalid OVM address');
-    require(baseArgs.trustedRemotes.length == 1, 'Adapter can only have one remote');
 
     return
       MantleAdapterDeploymentHelper.getAdapterCode(

--- a/scripts/contract_extensions/MantleAdapter.sol
+++ b/scripts/contract_extensions/MantleAdapter.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.8;
+
+import {TestNetChainIds} from 'solidity-utils/contracts/utils/ChainHelpers.sol';
+import {MantleAdapter, IOpAdapter, IMantleAdapter} from '../../src/contracts/adapters/mantle/MantleAdapter.sol';
+
+/**
+ * @title MantleAdapterTestnet
+ * @author BGD Labs
+ */
+contract MantleAdapterTestnet is MantleAdapter {
+  /**
+   * @param params object containing the necessary parameters to initialize the contract
+   */
+  constructor(IMantleAdapter.MantleParams memory params) MantleAdapter(params) {}
+
+  /// @inheritdoc IOpAdapter
+  function isDestinationChainIdSupported(uint256 chainId) public pure override returns (bool) {
+    return chainId == TestNetChainIds.MANTLE_SEPOLIA;
+  }
+
+  /// @inheritdoc IOpAdapter
+  function getOriginChainId() public pure override returns (uint256) {
+    return TestNetChainIds.ETHEREUM_SEPOLIA;
+  }
+}

--- a/src/contracts/adapters/mantle/IMantleAdapter.sol
+++ b/src/contracts/adapters/mantle/IMantleAdapter.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import {IBaseAdapter} from '../IBaseAdapter.sol';
+
+/**
+ * @title IMantleAdapter
+ * @author BGD Labs
+ * @notice interface containing the events, objects and method definitions used in the Mantle bridge adapter
+ */
+interface IMantleAdapter is IBaseAdapter {
+  /**
+   * @notice struct used to pass parameters to the Mantle constructor
+   * @param crossChainController address of the cross chain controller that will use this bridge adapter
+   * @param ovmCrossDomainMessenger Mantle entry point address
+   * @param providerGasLimit base gas limit used by the bridge adapter
+   * @param trustedRemotes list of remote configurations to set as trusted
+   */
+  struct MantleParams {
+    address crossChainController;
+    address ovmCrossDomainMessenger;
+    uint256 providerGasLimit;
+    TrustedRemotesConfig[] trustedRemotes;
+  }
+}

--- a/src/contracts/adapters/mantle/MantleAdapter.sol
+++ b/src/contracts/adapters/mantle/MantleAdapter.sol
@@ -12,6 +12,7 @@ import {IMantleAdapter} from './IMantleAdapter.sol';
         is called via delegate call
  * @dev note that this adapter can only be used for the communication path ETHEREUM -> MANTLE
  * @dev note that this adapter inherits from Optimism adapter and overrides only supported chain
+ * @dev note that max total gas limit is 1M
  */
 contract MantleAdapter is OpAdapter, IMantleAdapter {
   /**

--- a/src/contracts/adapters/mantle/MantleAdapter.sol
+++ b/src/contracts/adapters/mantle/MantleAdapter.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import {ChainIds} from 'solidity-utils/contracts/utils/ChainHelpers.sol';
+import {OpAdapter, IOpAdapter} from '../optimism/OpAdapter.sol';
+import {IMantleAdapter} from './IMantleAdapter.sol';
+/**
+ * @title MantleAdapter
+ * @author BGD Labs
+ * @notice Mantle bridge adapter. Used to send and receive messages cross chain between Ethereum and Mantle
+ * @dev it uses the eth balance of CrossChainController contract to pay for message bridging as the method to bridge
+        is called via delegate call
+ * @dev note that this adapter can only be used for the communication path ETHEREUM -> MANTLE
+ * @dev note that this adapter inherits from Optimism adapter and overrides only supported chain
+ */
+contract MantleAdapter is OpAdapter, IMantleAdapter {
+  /**
+   * @param params object containing the necessary parameters to initialize the contract
+   */
+  constructor(
+    MantleParams memory params
+  )
+    OpAdapter(
+      params.crossChainController,
+      params.ovmCrossDomainMessenger,
+      params.providerGasLimit,
+      'Mantle native adapter',
+      params.trustedRemotes
+    )
+  {}
+
+  /// @inheritdoc IOpAdapter
+  function isDestinationChainIdSupported(
+    uint256 chainId
+  ) public view virtual override returns (bool) {
+    return chainId == ChainIds.MANTLE;
+  }
+
+  /// @inheritdoc IOpAdapter
+  function getOriginChainId() public pure virtual override returns (uint256) {
+    return ChainIds.ETHEREUM;
+  }
+}

--- a/tests/adapters/MantleAdapter.t.sol
+++ b/tests/adapters/MantleAdapter.t.sol
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import {IMantleAdapter, IBaseAdapter} from '../../src/contracts/adapters/mantle/IMantleAdapter.sol';
+import {MantleAdapter} from '../../src/contracts/adapters/mantle/MantleAdapter.sol';
+import {ICrossChainReceiver} from '../../src/contracts/interfaces/ICrossChainReceiver.sol';
+import {ChainIds} from 'solidity-utils/contracts/utils/ChainHelpers.sol';
+import {Errors} from '../../src/contracts/libs/Errors.sol';
+import {BaseAdapterTest} from './BaseAdapterTest.sol';
+import {ICrossDomainMessenger} from '../../src/contracts/adapters/optimism/interfaces/ICrossDomainMessenger.sol';
+
+
+contract MantleAdapterTest is BaseAdapterTest {
+  MantleAdapter internal mantleAdapter;
+  event SetTrustedRemote(uint256 indexed originChainId, address indexed originForwarder);
+
+  modifier setMantleAdapter(
+    address crossChainController,
+    address ovmCrossDomainMessenger,
+    address originForwarder,
+    uint256 baseGasLimit,
+    uint256 originChainId
+  ) {
+    vm.assume(crossChainController != tx.origin);
+    vm.assume(baseGasLimit < 10_000_000);
+    _assumeSafeAddress(crossChainController);
+    _assumeSafeAddress(ovmCrossDomainMessenger);
+    vm.assume(originForwarder != address(0));
+    vm.assume(originChainId > 0);
+
+    IBaseAdapter.TrustedRemotesConfig memory originConfig = IBaseAdapter.TrustedRemotesConfig({
+      originForwarder: originForwarder,
+      originChainId: originChainId
+    });
+    IBaseAdapter.TrustedRemotesConfig[]
+      memory originConfigs = new IBaseAdapter.TrustedRemotesConfig[](1);
+    originConfigs[0] = originConfig;
+
+    mantleAdapter = new MantleAdapter(
+      IMantleAdapter.MantleParams({
+        crossChainController: crossChainController,
+        ovmCrossDomainMessenger: ovmCrossDomainMessenger,
+        providerGasLimit: baseGasLimit,
+        trustedRemotes: originConfigs
+      })
+    );
+    _;
+  }
+
+  struct Params {
+    address ovmCrossDomainMessenger;
+    address receiver;
+    uint256 dstGasLimit;
+    address caller;
+  }
+
+  function setUp() public {}
+
+  function testInitialize(
+    address crossChainController,
+    address ovmCrossDomainMessenger,
+    address originForwarder,
+    uint256 baseGasLimit,
+    uint256 originChainId
+  )
+    public
+    setMantleAdapter(
+      crossChainController,
+      ovmCrossDomainMessenger,
+      originForwarder,
+      baseGasLimit,
+      originChainId
+    )
+  {
+    assertEq(mantleAdapter.getTrustedRemoteByChainId(originChainId), originForwarder);
+  }
+
+  function testForwardMessage(
+    address crossChainController,
+    address ovmCrossDomainMessenger,
+    address originForwarder,
+    uint256 baseGasLimit,
+    uint256 originChainId
+  )
+    public
+    setMantleAdapter(
+      crossChainController,
+      ovmCrossDomainMessenger,
+      originForwarder,
+      baseGasLimit,
+      originChainId
+    )
+  {
+    _testForwardMessage(
+      Params({
+        ovmCrossDomainMessenger: ovmCrossDomainMessenger,
+        receiver: address(135961),
+        dstGasLimit: 12,
+        caller: address(12354)
+      })
+    );
+  }
+
+  function testForwardMessageWhenChainNotSupported(
+    address crossChainController,
+    address ovmCrossDomainMessenger,
+    address originForwarder,
+    uint256 baseGasLimit,
+    uint256 originChainId,
+    uint256 dstGasLimit,
+    address receiver,
+    bytes memory message
+  )
+    public
+    setMantleAdapter(
+      crossChainController,
+      ovmCrossDomainMessenger,
+      originForwarder,
+      baseGasLimit,
+      originChainId
+    )
+  {
+    vm.assume(receiver != address(0));
+
+    vm.expectRevert(bytes(Errors.DESTINATION_CHAIN_ID_NOT_SUPPORTED));
+    mantleAdapter.forwardMessage(receiver, dstGasLimit, 11, message);
+  }
+
+  function testForwardMessageWhenWrongReceiver(
+    address crossChainController,
+    address ovmCrossDomainMessenger,
+    address originForwarder,
+    uint256 baseGasLimit,
+    uint256 originChainId,
+    uint256 dstGasLimit,
+    bytes memory message
+  )
+    public
+    setMantleAdapter(
+      crossChainController,
+      ovmCrossDomainMessenger,
+      originForwarder,
+      baseGasLimit,
+      originChainId
+    )
+  {
+    vm.expectRevert(bytes(Errors.RECEIVER_NOT_SET));
+    mantleAdapter.forwardMessage(address(0), dstGasLimit, ChainIds.MANTLE, message);
+  }
+
+  function testReceive(
+    address crossChainController,
+    address ovmCrossDomainMessenger,
+    address originForwarder,
+    uint256 baseGasLimit,
+    bytes memory message
+  )
+    public
+    setMantleAdapter(crossChainController, ovmCrossDomainMessenger, originForwarder, baseGasLimit, 1)
+  {
+    hoax(ovmCrossDomainMessenger);
+
+    vm.mockCall(
+      crossChainController,
+      abi.encodeWithSelector(ICrossChainReceiver.receiveCrossChainMessage.selector),
+      abi.encode()
+    );
+    vm.expectCall(
+      crossChainController,
+      0,
+      abi.encodeWithSelector(ICrossChainReceiver.receiveCrossChainMessage.selector, message, 1)
+    );
+    vm.mockCall(
+      ovmCrossDomainMessenger,
+      abi.encodeWithSelector(ICrossDomainMessenger.xDomainMessageSender.selector),
+      abi.encode(originForwarder)
+    );
+    mantleAdapter.ovmReceive(message);
+  }
+
+  function testReceiveWhenRemoteNotTrusted(
+    address crossChainController,
+    address ovmCrossDomainMessenger,
+    address originForwarder,
+    uint256 baseGasLimit,
+    bytes memory message,
+    address remote
+  )
+    public
+    setMantleAdapter(crossChainController, ovmCrossDomainMessenger, originForwarder, baseGasLimit, 1)
+  {
+    vm.assume(remote != originForwarder);
+    hoax(ovmCrossDomainMessenger);
+
+    vm.mockCall(
+      ovmCrossDomainMessenger,
+      abi.encodeWithSelector(ICrossDomainMessenger.xDomainMessageSender.selector),
+      abi.encode(remote)
+    );
+    vm.expectRevert(bytes(Errors.REMOTE_NOT_TRUSTED));
+
+    mantleAdapter.ovmReceive(message);
+  }
+
+  function testReceiveWhenIncorrectOriginChainId(
+    address crossChainController,
+    address ovmCrossDomainMessenger,
+    address originForwarder,
+    uint256 baseGasLimit,
+    bytes memory message,
+    uint256 originChainId
+  )
+    public
+    setMantleAdapter(
+      crossChainController,
+      ovmCrossDomainMessenger,
+      originForwarder,
+      baseGasLimit,
+      originChainId
+    )
+  {
+    vm.assume(originChainId != 1);
+    hoax(ovmCrossDomainMessenger);
+
+    vm.mockCall(
+      ovmCrossDomainMessenger,
+      abi.encodeWithSelector(ICrossDomainMessenger.xDomainMessageSender.selector),
+      abi.encode(originForwarder)
+    );
+    vm.expectRevert(bytes(Errors.REMOTE_NOT_TRUSTED));
+
+    mantleAdapter.ovmReceive(message);
+  }
+
+  function _testForwardMessage(Params memory params) internal {
+    bytes memory message = abi.encode('test message');
+
+    hoax(params.caller, 10 ether);
+
+    vm.mockCall(
+      params.ovmCrossDomainMessenger,
+      abi.encodeWithSelector(ICrossDomainMessenger.sendMessage.selector),
+      abi.encode()
+    );
+    (bool success, bytes memory returnData) = address(mantleAdapter).delegatecall(
+      abi.encodeWithSelector(
+        IBaseAdapter.forwardMessage.selector,
+        params.receiver,
+        params.dstGasLimit,
+        ChainIds.MANTLE,
+        message
+      )
+    );
+    vm.clearMockedCalls();
+
+    assertEq(success, true);
+    assertEq(returnData, abi.encode(params.ovmCrossDomainMessenger, 0));
+  }
+}


### PR DESCRIPTION
On this pr we add the Bridge adapter for Mantle network
- As Mantle uses OP stack, the bridge just inherits from OP Adapter (similar to Base and Metis etc)

test tx of message bridging: https://mantlescan.info/tx/0x7f85a31a2e4bf0353f7d32c2dfe5ee6a7260053d0060a248056c88148d9c5b51/eventlog
