### PR TITLE
feat: Chainlink Emergency Oracle update for ccc rev 4

### DIFF
--- a/src/contracts/revisions/update_to_rev_4/CrossChainControllerWithEmergencyMode.sol
+++ b/src/contracts/revisions/update_to_rev_4/CrossChainControllerWithEmergencyMode.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.8;
+
+import {CrossChainControllerWithEmergencyMode} from '../../CrossChainControllerWithEmergencyMode.sol';
+import {IReinitialize} from './IReinitialize.sol';
+
+/**
+ * @title CrossChainControllerWithEmergencyModeUpgradeRev4
+ * @author BGD Labs
+ * @notice Contract inheriting from CrossChainControllerWithEmergencyMode with the addition of re initialization method
+ * @dev reinitializer is not used on parent CrossChainController, so this contract is needed to be able to initialize CCC with a new implementation
+ * @dev it initializes the new implementation with the addition of the required Chainlink Emergency Oracle address
+ */
+contract CrossChainControllerWithEmergencyModeUpgradeRev4 is
+  CrossChainControllerWithEmergencyMode,
+  IReinitialize
+{
+  constructor(address clEmergencyOracle) CrossChainControllerWithEmergencyMode(clEmergencyOracle) {}
+
+  /// @inheritdoc IReinitialize
+  function initializeRevision(address chainlinkEmergencyOracle) external reinitializer(4) {
+    _updateCLEmergencyOracle(chainlinkEmergencyOracle);
+  }
+}

--- a/src/contracts/revisions/update_to_rev_4/IReinitialize.sol
+++ b/src/contracts/revisions/update_to_rev_4/IReinitialize.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/**
+ * @title IReinitialize
+ * @author BGD Labs
+ * @notice interface containing re initialization method
+ */
+interface IReinitialize {
+  /**
+   * @notice method called to re initialize the proxy
+   * @param chainlinkEmergencyOracle address of the Chainlink emergency oracle
+   */
+  function initializeRevision(address chainlinkEmergencyOracle) external;
+}


### PR DESCRIPTION
Adds Revision 4, which consist of the CrossChainControllerWithEmergencyOracle instance with emergency oracle initialization only.
This instance will be used to update the CCC of all the networks which currently do not have the EmergencyOracle.