### PR TITLE
feat: add X Layer network

### DIFF
--- a/foundry.lock
+++ b/foundry.lock
@@ -1,0 +1,8 @@
+{
+  "lib/solidity-utils": {
+    "tag": {
+      "name": "v1.1.2",
+      "rev": "d19a9d0f0fa7271480cfac077e6b79a3d80d7d1f"
+    }
+  }
+}

--- a/foundry.lock
+++ b/foundry.lock
@@ -1,8 +1,5 @@
 {
   "lib/solidity-utils": {
-    "tag": {
-      "name": "v1.1.2",
-      "rev": "d19a9d0f0fa7271480cfac077e6b79a3d80d7d1f"
-    }
+    "rev": "d9cfaf61dc2b498a15ff60944606a7320a6cdb58"
   }
 }

--- a/scripts/Adapters/DeployXLayer.sol
+++ b/scripts/Adapters/DeployXLayer.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import {XLayerAdapter, IBaseAdapter, XLayerAdapterArgs as XLayerAdapterArgsType} from '../../src/contracts/adapters/xLayer/xLayerAdapter.sol';
+import './BaseAdapterScript.sol';
+
+library XLayerAdapterDeploymentHelper {
+  struct XLayerAdapterArgs {
+    BaseAdapterArgs baseArgs;
+    address ovm;
+  }
+
+  function getAdapterCode(
+    XLayerAdapterArgs memory xLayerArgs
+  ) internal pure returns (bytes memory) {
+    bytes memory creationCode = type(XLayerAdapter).creationCode;
+
+    return
+      abi.encodePacked(
+        creationCode,
+        abi.encode(
+          XLayerAdapterArgsType({
+            crossChainController: xLayerArgs.baseArgs.crossChainController,
+            ovmCrossDomainMessenger: xLayerArgs.ovm,
+            providerGasLimit: xLayerArgs.baseArgs.providerGasLimit,
+            trustedRemotes: xLayerArgs.baseArgs.trustedRemotes
+          })
+        )
+      );
+  }
+}
+
+abstract contract BaseXLayerAdapter is BaseAdapterScript {
+  function OVM() internal view virtual returns (address);
+
+  function _getAdapterByteCode(
+    BaseAdapterArgs memory baseArgs
+  ) internal view override returns (bytes memory) {
+    require(OVM() != address(0), 'Invalid OVM address');
+
+    return
+      XLayerAdapterDeploymentHelper.getAdapterCode(
+        XLayerAdapterDeploymentHelper.XLayerAdapterArgs({baseArgs: baseArgs, ovm: OVM()})
+      );
+  }
+}

--- a/src/contracts/adapters/xLayer/xLayerAdapter.sol
+++ b/src/contracts/adapters/xLayer/xLayerAdapter.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import {BaseAdapter, IBaseAdapter} from '../BaseAdapter.sol';
+import {Errors} from '../../libs/Errors.sol';
+import {ChainIds} from 'solidity-utils/contracts/utils/ChainHelpers.sol';
+import {OpAdapter, IOpAdapter} from '../optimism/OpAdapter.sol';
+
+/**
+ * @param crossChainController address of the cross chain controller that will use this bridge adapter
+ * @param ovmCrossDomainMessenger XLayer entry point address
+ * @param providerGasLimit base gas limit used by the bridge adapter
+ * @param trustedRemotes list of remote configurations to set as trusted
+ */
+struct XLayerAdapterArgs {
+  address crossChainController;
+  address ovmCrossDomainMessenger;
+  uint256 providerGasLimit;
+  IBaseAdapter.TrustedRemotesConfig[] trustedRemotes;
+}
+
+/**
+ * @title XLayerAdapter
+ * @author BGD Labs
+ * @notice XLayer bridge adapter. Used to send and receive messages cross chain between Ethereum and XLayer
+ * @dev it uses the eth balance of CrossChainController contract to pay for message bridging as the method to bridge
+        is called via delegate call
+ * @dev note that this adapter can only be used for the communication path ETHEREUM -> XLAYER
+ * @dev note that this adapter inherits from Optimism adapter and overrides only supported chain
+ */
+contract XLayerAdapter is OpAdapter {
+  /**
+   * @param args XLayerAdapterArgs necessary to initialize the adapter
+   */
+  constructor(
+    XLayerAdapterArgs memory args
+  )
+    OpAdapter(
+      args.crossChainController,
+      args.ovmCrossDomainMessenger,
+      args.providerGasLimit,
+      'XLayer native adapter',
+      args.trustedRemotes
+    )
+  {}
+
+  /// @inheritdoc IOpAdapter
+  function isDestinationChainIdSupported(
+    uint256 chainId
+  ) public view virtual override returns (bool) {
+    return chainId == ChainIds.XLAYER;
+  }
+
+  /// @inheritdoc IOpAdapter
+  function getOriginChainId() public pure virtual override returns (uint256) {
+    return ChainIds.ETHEREUM;
+  }
+}


### PR DESCRIPTION
Adds X Layer network bridge adapter (As X Layer will be migrated to the OP stack, we inherit from the OP adapter without the need to change any of the base logic. (same process used for all the OP Stack bridge adapters))

- it also updates solidity-utils lib to the latest commit (so that it includes the X Layer configurations (scripts, chainIds, etc)