### PR TITLE
Add SPDX-License-Identifier headers to Certora harness files

### DIFF
--- a/security/certora/harness/BaseCrossChainControllerHarness.sol
+++ b/security/certora/harness/BaseCrossChainControllerHarness.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.8;
 
 import {BaseCrossChainController} from '../munged/src/contracts/BaseCrossChainController.sol';

--- a/security/certora/harness/BaseReceiverPortalDummy.sol
+++ b/security/certora/harness/BaseReceiverPortalDummy.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.8;
 
 contract BaseReceiverPortalDummy {

--- a/security/certora/harness/CrossChainControllerHarness.sol
+++ b/security/certora/harness/CrossChainControllerHarness.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.8;
 
 import {CrossChainController} from '../../src/contracts/CrossChainController.sol';

--- a/security/certora/harness/CrossChainControllerWithEmergencyModeHarness.sol
+++ b/security/certora/harness/CrossChainControllerWithEmergencyModeHarness.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.8;
 
 //import {CrossChainControllerWithEmergencyMode} from '../../../src/contracts/CrossChainControllerWithEmergencyMode.sol';

--- a/security/certora/harness/CrossChainForwarderHarness.sol
+++ b/security/certora/harness/CrossChainForwarderHarness.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.16;
 
 import {CrossChainForwarder} from "../munged/src/contracts/CrossChainForwarder.sol";

--- a/security/certora/harness/CrossChainForwarderHarnessED.sol
+++ b/security/certora/harness/CrossChainForwarderHarnessED.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.16;
 
 import {CrossChainForwarder} from "../munged/src/contracts/CrossChainForwarder.sol";

--- a/security/certora/harness/CrossChainReceiverHarness.sol
+++ b/security/certora/harness/CrossChainReceiverHarness.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.8;
 
 import {CrossChainReceiverHarnessAbstract} from './CrossChainReceiverHarnessAbstract.sol';

--- a/security/certora/harness/CrossChainReceiverHarnessAbstract.sol
+++ b/security/certora/harness/CrossChainReceiverHarnessAbstract.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.8;
 
 import {CrossChainReceiver} from '../munged/src/contracts/CrossChainReceiver.sol';


### PR DESCRIPTION
This PR adds SPDX-License-Identifier headers to Certora harness files for license consistency.